### PR TITLE
Add Playwright tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+test-results/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Then visit `http://localhost:8000/index.html` in your browser. `script.js` fetch
 
 Manual testing instructions are documented in [MANUAL_TESTING_PLAN.md](MANUAL_TESTING_PLAN.md).
 
+## Automated Tests
+
+Playwright tests live in `tests/`. Install dependencies and run:
+
+```bash
+npm install
+npm test
+```
+
+The tests start a local server automatically and cover view toggling, theme switching, and favorites persistence.
+
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,80 @@
+{
+  "name": "ps2links",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ps2links",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.52.0",
+        "playwright": "^1.52.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ps2links",
+  "version": "1.0.0",
+  "description": "PS2 Resource Links is a static collection of PlayStation 2 related sites. The page is built from `links.json` and displayed with simple JavaScript and CSS.",
+  "main": "main.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.52.0",
+    "playwright": "^1.52.0"
+  }
+}

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,0 +1,18 @@
+const { defineConfig } = require('@playwright/test');
+const path = require('path');
+
+module.exports = defineConfig({
+  testDir: __dirname,
+  use: {
+    headless: true,
+    baseURL: 'http://localhost:3000',
+    viewport: { width: 1280, height: 720 },
+  },
+  webServer: {
+    command: 'python3 -m http.server 3000',
+    port: 3000,
+    cwd: path.resolve(__dirname, '..'),
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -1,0 +1,44 @@
+const { test, expect } = require('@playwright/test');
+
+// Helper to get first link star button
+async function getFirstStar(page) {
+  return page.locator('.content .favorite-btn').first();
+}
+
+const BASE = 'http://localhost:3000';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`${BASE}/index.html`);
+  await page.locator('.favorite-btn').first().waitFor();
+});
+
+test('view toggling', async ({ page }) => {
+  await page.click('#thumbnail-view-btn');
+  const firstContent = page.locator('main section .content').first();
+  await expect(firstContent).toHaveClass(/thumbnail-view/);
+
+  await page.click('#list-view-btn');
+  await expect(firstContent).toHaveClass(/list-view/);
+});
+
+test('theme switching', async ({ page }) => {
+  const body = page.locator('body');
+  const initial = await body.getAttribute('class');
+  await page.click('#theme-toggle-btn');
+  const toggled = await body.getAttribute('class');
+  expect(toggled).not.toBe(initial);
+  const stored = await page.evaluate(() => localStorage.getItem('theme'));
+  expect(stored).not.toBeNull();
+});
+
+test('favorites persistence', async ({ page }) => {
+  const header = page.locator('main h2.collapsible').first();
+  await header.click();
+  const star = await getFirstStar(page);
+  await star.click({ force: true });
+  await expect(star).toHaveClass(/favorited/);
+
+  await page.reload();
+  const starAfter = await getFirstStar(page);
+  await expect(starAfter).toHaveClass(/favorited/);
+});


### PR DESCRIPTION
## Summary
- add Playwright configuration and UI tests
- ignore Node modules and test artifacts
- document running tests in README

## Testing
- `npm install`
- `npm test` *(fails: page.goto net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6845266bcb68832184dfb47ccc368202