### PR TITLE
Fix collapsibles and search, improve favorites update

### DIFF
--- a/collapsibles.js
+++ b/collapsibles.js
@@ -7,7 +7,8 @@ export function initializeCollapsibles() {
         collapsible.parentNode.replaceChild(newCollapsible, collapsible);
 
         const categoryName = newCollapsible.textContent;
-        const content = newCollapsible.nextElementSibling;
+        const section = newCollapsible.parentElement;
+        const content = section ? section.querySelector('.content') : null;
 
         newCollapsible.addEventListener('click', () => {
             if (content) {
@@ -28,7 +29,8 @@ export function initializeCollapsibles() {
 
     document.querySelectorAll('.collapsible').forEach(coll => {
         const categoryName = coll.textContent;
-        const content = coll.nextElementSibling;
+        const section = coll.parentElement;
+        const content = section ? section.querySelector('.content') : null;
         if (content) {
             if (state.expandedCategories.includes(categoryName)) {
                 content.style.display = state.currentView === 'thumbnail' ? 'grid' : 'block';

--- a/linkUtils.js
+++ b/linkUtils.js
@@ -10,10 +10,10 @@ export function getFaviconUrl(url) {
 
 export function createLinkListItem(linkObj, isFavorited, toggleFavorite) {
     const li = document.createElement('li');
+    li.setAttribute('data-url', linkObj.url);
     const a = document.createElement('a');
     a.href = linkObj.url;
     a.target = '_blank';
-    a.setAttribute('data-url', linkObj.url);
 
     const img = document.createElement('img');
     img.src = getFaviconUrl(linkObj.url);

--- a/search.js
+++ b/search.js
@@ -8,7 +8,7 @@ export function handleSearchInput() {
 
     sections.forEach((section) => {
         const collapsibleHeader = section.querySelector('h2.collapsible');
-        const contentElement = collapsibleHeader ? collapsibleHeader.nextElementSibling : null;
+        const contentElement = section.querySelector('.content');
         if (!collapsibleHeader || !contentElement) return;
 
         let hasMatches = false;

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -42,3 +42,27 @@ test('favorites persistence', async ({ page }) => {
   const starAfter = await getFirstStar(page);
   await expect(starAfter).toHaveClass(/favorited/);
 });
+
+test('category collapsible toggle', async ({ page }) => {
+  const firstSection = page.locator('main > section').first();
+  const header = firstSection.locator('h2.collapsible');
+  const content = firstSection.locator('.content');
+
+  await expect(content).not.toBeVisible();
+  await header.click();
+  await expect(content).toBeVisible();
+  await header.click();
+  await expect(content).not.toBeVisible();
+});
+
+test('search filters categories', async ({ page }) => {
+  const search = page.locator('#search-bar');
+  await search.fill('Romhacking');
+
+  const visibleSections = page.locator('main > section:visible');
+  await expect(visibleSections).toHaveCount(1);
+  await expect(visibleSections.first()).toContainText('Romhacking.net Forum');
+
+  await search.fill('');
+  await expect(page.locator('main > section:visible').first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- target the correct `.content` node when toggling collapsibles
- search logic also finds `.content` within the section
- update list view markup so the star button updates properly
- expand Playwright tests to cover collapsible toggle and searching

## Testing
- `npm test` *(fails: `playwright` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68452944495883218753dee4ce4858a2