### PR TITLE
Fix collapsible state on search clear

### DIFF
--- a/search.js
+++ b/search.js
@@ -1,4 +1,5 @@
 import { state } from './state.js';
+import { initializeCollapsibles } from './collapsibles.js';
 
 export function handleSearchInput() {
     const searchBar = document.getElementById('search-bar');
@@ -58,5 +59,6 @@ export function handleSearchInput() {
                 collapsibleHeader.classList.remove('search-match');
             }
         });
+        initializeCollapsibles();
     }
 }


### PR DESCRIPTION
## Summary
- reapply collapsible expansion state when clearing search
- import the collapsible initializer into the search module

## Testing
- `npx playwright install --with-deps`
- `npx playwright test` *(fails: net::ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684534b3d28883218b35465960629c8e