### PR TITLE
Add collapsible arrow indicators

### DIFF
--- a/collapsibles.js
+++ b/collapsibles.js
@@ -15,9 +15,13 @@ export function initializeCollapsibles() {
                 const isExpanded = content.style.display !== 'none' && content.style.display !== '';
                 if (isExpanded) {
                     content.style.display = 'none';
+                    newCollapsible.classList.remove('expanded');
+                    newCollapsible.classList.add('collapsed');
                     state.expandedCategories = state.expandedCategories.filter(cat => cat !== categoryName);
                 } else {
                     content.style.display = state.currentView === 'thumbnail' ? 'grid' : 'block';
+                    newCollapsible.classList.remove('collapsed');
+                    newCollapsible.classList.add('expanded');
                     if (!state.expandedCategories.includes(categoryName)) {
                         state.expandedCategories.push(categoryName);
                     }
@@ -34,8 +38,12 @@ export function initializeCollapsibles() {
         if (content) {
             if (state.expandedCategories.includes(categoryName)) {
                 content.style.display = state.currentView === 'thumbnail' ? 'grid' : 'block';
+                coll.classList.add('expanded');
+                coll.classList.remove('collapsed');
             } else {
                 content.style.display = 'none';
+                coll.classList.add('collapsed');
+                coll.classList.remove('expanded');
             }
         }
     });

--- a/styles.css
+++ b/styles.css
@@ -266,6 +266,28 @@ h2.collapsible {
     letter-spacing: 1px;
     /* margin-bottom: 10px; */ /* This space is now potentially handled by category-view-toggle or content's margin-top */
     text-shadow: 1px 1px 2px rgba(0,0,0,0.7);
+    position: relative;
+}
+
+h2.collapsible::after {
+    content: '';
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0.35em 0.35em 0.35em 0;
+    border-color: transparent currentColor transparent transparent;
+    margin-left: 10px;
+    transition: transform 0.2s ease;
+    vertical-align: middle;
+}
+
+h2.collapsible.expanded::after {
+    transform: rotate(90deg);
+}
+
+h2.collapsible.collapsed::after {
+    transform: rotate(0deg);
 }
 
 h2.collapsible:hover {


### PR DESCRIPTION
## Summary
- add pseudo-element arrow to `.collapsible` headers and rotate when expanded or collapsed
- toggle `expanded` and `collapsed` classes in `collapsibles.js`

## Testing
- `npm test` *(fails: browser missing)*

------
https://chatgpt.com/codex/tasks/task_e_684535c6dd208321a5b1e2af36487cba