### PR TITLE
refactor: Sidebar pushes content instead of overlapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -223,6 +223,8 @@ header h1 { /* More specific selector for the main title if needed */
 
 main {
     padding: 20px;
+    margin-left: 0; /* Default margin */
+    transition: margin-left 0.3s ease-in-out;
 }
 
 /* Default main layout (single column for sections) */
@@ -765,7 +767,7 @@ body.light-mode footer p {
     font-family: "Orbitron", "Arial", sans-serif;
     font-size: 0.9em;
     box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-    transition: background-color 0.3s ease;
+    transition: background-color 0.3s ease, left 0.3s ease-in-out;
 }
 
 #sidebar-toggle:hover {
@@ -795,4 +797,13 @@ body.light-mode #sidebar-toggle {
 
 body.light-mode #sidebar-toggle:hover {
     background-color: #7986CB; /* Lighter indigo on hover */
+}
+
+/* When sidebar is open, shift main content and toggle button */
+#sidebar.open ~ main {
+    margin-left: 200px; /* Matches sidebar width */
+}
+
+#sidebar.open ~ #sidebar-toggle {
+    left: 220px; /* Sidebar width (200px) + original left offset (20px) */
 }


### PR DESCRIPTION
This commit refines the sidebar functionality based on your feedback. The sidebar now pushes the main content and the sidebar toggle button to the right when it opens, instead of overlapping them.

Changes include:
- Modified `styles.css` to add `margin-left` to the `main` element and adjust the `left` property of the `#sidebar-toggle` button when the sidebar is open.
- Ensured smooth transitions for these movements to match the sidebar's open/close animation.
- The core JavaScript logic for toggling the sidebar's visibility (`open` class on `#sidebar`) remains unchanged, as the new behavior is handled by CSS selectors based on this class.