### PR TITLE
Fix: Ensure multiple thumbnails per row within categories in global t…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -235,7 +235,7 @@ main {
 /* Multi-column layout for sections when thumbnail categories are active */
 main.thumbnail-categories-active {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); /* Adjust minmax as needed */
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr)); /* Adjust minmax as needed */
     gap: 20px;
 }
 


### PR DESCRIPTION
…humbnail view

When the global view mode is set to "Thumbnail View", the `main` element becomes a grid container for `section` elements. The previous minimum width for these sections (`minmax(300px, 1fr)`) was insufficient, after section padding, to allow the contained `.content.thumbnail-view` (which is also a grid for individual thumbnail items) to display more than one 150px thumbnail item per row.

This change increases the minimum width for sections in this mode to `minmax(350px, 1fr)`. This provides enough space (approx. 320px) within the section's content area for at least two 150px thumbnails and their 15px gap (total 315px) to be displayed side-by-side.

This addresses the issue where thumbnail views within categories and the favorites section would only show one item per row when the main page layout was also set to thumbnails for categories.