### PR TITLE
Refactor: Adjust UI for Thumbnails and Favorites Toggles

### DIFF
--- a/main.js
+++ b/main.js
@@ -145,7 +145,6 @@ function createFavoritesSectionElements() {
 
     toggleContainer.appendChild(listBtn);
     toggleContainer.appendChild(thumbBtn);
-    h2.appendChild(toggleContainer); // Add toggle buttons to the h2 for flex layout
 
     const contentDiv = document.createElement('div');
     contentDiv.id = 'favorites-content';
@@ -153,6 +152,7 @@ function createFavoritesSectionElements() {
     // Initial view mode class will be set by populateFavoritesContent
 
     section.appendChild(h2);
+    section.appendChild(toggleContainer); // Add toggle buttons to the section
     section.appendChild(contentDiv);
 
     // Event listeners for toggle buttons

--- a/styles.css
+++ b/styles.css
@@ -598,15 +598,6 @@ body.light-mode section {
     /* align-self: start; is already on the general section style */
 }
 
-/* Styles for the favorites section's view toggle container specifically */
-/* This assumes .category-view-toggle is nested directly in h2.collapsible */
-#favorites-section h2.collapsible .category-view-toggle {
-    margin-left: auto; /* Pushes toggle to the right if space is available */
-    margin-right: 5px; /* Give some space from the expand/collapse arrow */
-    /* Override any margin-bottom from the generic .category-view-toggle if needed */
-    margin-bottom: 0;
-}
-
 /* Ensure the title span in H2 doesn't get squished if H2 is flex */
 #favorites-section h2.collapsible > span:first-child {
     flex-grow: 1; /* Allows title to take available space */


### PR DESCRIPTION
- Thumbnail views: I confirmed the existing CSS provides a tile-like grid (150x150px items). I made no changes to this aspect.
- Favorites view toggles:
    - I modified `main.js` to move the view toggle buttons (List/Thumbnail) for the Favorites section from within the H2 header to be directly under it, as a child of the section. This makes its structure consistent with other categories.
    - I updated `styles.css` by removing a specific rule for `#favorites-section h2.collapsible .category-view-toggle`. The general `.category-view-toggle` styles now correctly apply, ensuring consistent appearance and spacing for the Favorites toggles.

These changes address the issue of thumbnail layout and the positioning of Favorites view toggles.