### PR TITLE
Fix: Ensure categories display as tiles in both List and Thumbnail views

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -239,6 +239,12 @@ main.thumbnail-categories-active {
     gap: 20px;
 }
 
+main.list-categories-active {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    gap: 20px;
+}
+
 section {
     margin-bottom: 25px; /* This will apply in both list and grid view for spacing below sections */
     /* background-color: rgba(0, 0, 20, 0.7); /* Fallback if gradient not supported */

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -14,13 +14,19 @@ test.beforeEach(async ({ page }) => {
   await page.locator('main').waitFor({ timeout: 10000 });
 });
 
-test('view toggling', async ({ page }) => {
-  await page.click('#thumbnail-view-btn');
-  const firstContent = page.locator('main section .content').first();
-  await expect(firstContent).toHaveClass(/thumbnail-view/);
+test('view toggling and category layout', async ({ page }) => {
+  const mainElement = page.locator('main');
+  const firstContent = mainElement.locator('section .content').first();
 
+  // Test Thumbnail View
+  await page.click('#thumbnail-view-btn');
+  await expect(mainElement).toHaveCSS('display', 'grid'); // New assertion for main layout
+  await expect(firstContent).toHaveClass(/thumbnail-view/); // Existing assertion for content view
+
+  // Test List View
   await page.click('#list-view-btn');
-  await expect(firstContent).toHaveClass(/list-view/);
+  await expect(mainElement).toHaveCSS('display', 'grid'); // New assertion for main layout
+  await expect(firstContent).toHaveClass(/list-view/);     // Existing assertion for content view
 });
 
 test('theme switching', async ({ page }) => {


### PR DESCRIPTION
Previously, category sections were only displayed in a tiled (grid) layout when the global view was set to "Thumbnail View". When the global view was "List View", category sections would revert to a single-column layout.

This change modifies `styles.css` to apply the grid layout to the `main` element when `main.list-categories-active` class is active, consistent with `main.thumbnail-categories-active`. This ensures that category sections are always displayed as tiles, regardless of the global view setting. The global view toggle (List/Thumbnail) now primarily controls the default display style for links *within* each category.

The Playwright test 'view toggling and category layout' has been updated to verify this new behavior, ensuring the `main` element consistently uses `display: grid`. All tests pass.