### PR TITLE
Fix: Ensure main page list view stacks categories and verify toggle i…

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -240,9 +240,9 @@ main.thumbnail-categories-active {
 }
 
 main.list-categories-active {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
-    gap: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px; /* Keep the gap for spacing between items */
 }
 
 section {


### PR DESCRIPTION
…ndependence

The main page's 'List View' now correctly displays category sections in a single vertical column by changing `main.list-categories-active` CSS from `display: grid` to `display: flex; flex-direction: column;`.

This change addresses the issue where the main 'List View' still used a grid layout for category sections.

Additionally, I verified that:
- Global view toggles (header) control the layout of category sections (grid vs. single column).
- Individual category view toggles control the item layout (list vs. thumbnail) *within* that category.
- An explicitly set category view (e.g., Category A set to thumbnail) is preserved when the global view is changed.
- Categories without an explicit view setting correctly default their content display to the current global view.
- The 'Favorites' section's view toggle remains independent.