### PR TITLE
Add favorites section visibility test

### DIFF
--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -51,6 +51,20 @@ test('favorites persistence', async ({ page }) => {
   await expect(starAfter).toHaveClass(/favorited/);
 });
 
+test('favorites section shows and hides without reload', async ({ page }) => {
+  const header = page.locator('main h2.collapsible').first();
+  await header.click();
+
+  const star = await getFirstStar(page);
+  await star.click({ force: true });
+
+  const favoritesSection = page.locator('#favorites-section');
+  await expect(favoritesSection).toBeVisible();
+
+  await star.click({ force: true });
+  await expect(favoritesSection).toHaveCount(0);
+});
+
 test('category collapsible toggle', async ({ page }) => {
   const firstSection = page.locator('main > section').first();
   const header = firstSection.locator('h2.collapsible');


### PR DESCRIPTION
## Summary
- extend UI test suite to check favorites section visibility when starring

## Testing
- `npm test` *(fails: favorites section never visible)*

------
https://chatgpt.com/codex/tasks/task_e_684833e21db48321ab74dc0043c0899f