### PR TITLE
Connect favoritesUpdated events to refresh display

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,5 +402,7 @@ if (searchBar) {
     searchBar.addEventListener('input', handleSearchInput);
 }
 
-initializePage();
-setupSidebarToggle(); // Initialize sidebar toggle functionality
+initializePage().then(() => {
+    document.body.addEventListener('favoritesUpdated', refreshFavoritesDisplayIfNeeded);
+    setupSidebarToggle(); // Initialize sidebar toggle functionality
+});


### PR DESCRIPTION
## Summary
- listen for the `favoritesUpdated` event after page initialization
- update sidebar toggle setup timing

## Testing
- `npm install`
- `npm test` *(fails: favorites section shows and hides without reload)*

------
https://chatgpt.com/codex/tasks/task_e_68483533636c8321ab466428f93e0ac6