### PR TITLE
Fix favorites logic and test config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PS2 Resource Links is a static collection of PlayStation 2 related sites. The page is built from `links.json` and displayed with simple JavaScript and CSS.",
   "main": "main.js",
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test --config=tests/playwright.config.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- prevent infinite recursion when toggling theme and refreshing favorites
- hide empty favorites section and append it at the bottom when needed
- update npm test script to use the provided Playwright config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68483b9f524883219ec10daa2813c04a