### PR TITLE
Fix: Improve responsiveness of categories, headers, and content

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,7 @@ header h1 { /* More specific selector for the main title if needed */
     display: flex;
     justify-content: flex-end; /* Align to the right */
     align-items: center;
+    flex-wrap: wrap; /* Allow buttons to wrap on smaller screens */
     margin-bottom: 8px; /* Space below the toggles, before content area */
     gap: 5px; /* Space between buttons */
 }
@@ -251,7 +252,8 @@ main.list-categories-active {
 }
 
 section {
-    box-sizing: border-box; /* Add this line */
+    box-sizing: border-box;
+    width: 100%; /* Ensure sections take full available width */
     margin-bottom: 25px; /* This will apply in both list and grid view for spacing below sections */
     /* background-color: rgba(0, 0, 20, 0.7); /* Fallback if gradient not supported */
     background-image: linear-gradient(to bottom, rgba(10, 20, 50, 0.75), rgba(0, 0, 20, 0.85));
@@ -286,6 +288,8 @@ h2.collapsible {
     justify-content: space-between;
     align-items: center;
     overflow: hidden; /* Added */
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 
 h2.collapsible::after {
@@ -323,7 +327,8 @@ h2.collapsible:hover {
 }
 .content-expanded.thumbnail-view {
     display: grid; /* Default display for thumbnail content containers */
-    /* Keep existing grid-template-columns and gap from .content.thumbnail-view */
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 15px;
 }
 
 .content-collapsed {
@@ -412,8 +417,6 @@ h2.collapsible:hover {
 /* Thumbnail View Specific Styles */
 .content.thumbnail-view {
     /* display: grid; /* This will be handled by .content-expanded.thumbnail-view */
-    grid-template-columns: repeat(3, 1fr); /* Responsive grid */
-    gap: 15px; /* Space between thumbnails */
     padding: 10px 0; /* Padding for the container */
 }
 


### PR DESCRIPTION
This commit addresses an issue where the width of categories, category headers, and listed contents was not dynamic and did not adjust correctly based on screen size.

The following changes were made to styles.css:

- Made category sections (`<section>`) responsive by setting `width: 100%`.
- Adjusted category headers (`h2.collapsible`) to truncate long titles with an ellipsis and ensure they adapt to the parent section's width.
- Enabled wrapping for category view toggle buttons (`.category-view-toggle`) to prevent overflow on smaller screens.
- Verified that list view items (`.content.list-view`) correctly use available width and truncate long link text.
- Modified the thumbnail view grid (`.content-expanded.thumbnail-view`) to use `repeat(auto-fit, minmax(140px, 1fr))`, allowing the number of columns to adjust dynamically with screen size.
- Ensured that grid and gap properties for thumbnail view are correctly applied to the `.content-expanded.thumbnail-view` rule.
- Reviewed main layout containers (`main.list-categories-active` and `main.thumbnail-categories-active`) to confirm their existing flexbox/grid setups support responsive child sections.

These changes ensure that the specified UI elements now shrink or expand appropriately with the screen size, maintaining a more consistent and uniform appearance across different viewports.