### PR TITLE
fix: Correct invalid regular expressions in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -90,8 +90,7 @@ async function loadServices() {
             acc[category].push(service);
             return acc;
         }, {});
-        const normalize = (name) => name.replace(/^(\p{Emoji_Presentation}|\p{Em
-oji})\s*/u, '').trim().toLowerCase();
+        const normalize = (name) => name.replace(/^(\p{Emoji_Presentation}|\p{Emoji})\s*/u, '').trim().toLowerCase();
         const sortedCategoryNames = Object.keys(categories).sort((a, b) => norma
 lize(a).localeCompare(normalize(b)));
         for (const categoryName of sortedCategoryNames) {
@@ -308,8 +307,7 @@ function createServiceButton(service, favoritesSet, categoryName) {
     }
 
     if (categoryName) {
-        const catText = categoryName.replace(/^(\p{Emoji_Presentation}|\p{Emoji}
-)\s*/u, '').trim();
+        const catText = categoryName.replace(/^(\p{Emoji_Presentation}|\p{Emoji})\s*/u, '').trim();
         if (!tags.includes(catText)) {
             tags.push(catText);
         }


### PR DESCRIPTION
This commit fixes critical syntax errors in regular expressions within script.js that were preventing the script from parsing and executing. These errors were the cause of the previously reported "hollow shell" issue where no content or error messages appeared.

Specifically:
- Corrected a typo in the regex in the `normalize` function (around line 93) from `\p{Em_oji}` to `\p{Emoji}`.
- Corrected a similar typo in the regex in the `createServiceButton` function (around line 331) from `\p{Emoji }` to `\p{Emoji}`.

With these corrections, script.js should now execute correctly. This will either allow the page content to load as intended or, if further issues exist in data fetching or processing, the enhanced on-page error reporting (via `displayErrorInMain`) should now function and provide specific error details on the page.