### PR TITLE
Fix service worker registration syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,9 +41,9 @@
     </footer>
     <script src="./script.js"></script>
     <script>
-        if ('serviceWorker' in navigator) {{
+        if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('service-worker.js');
-        }}
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix invalid service worker registration snippet in `index.html`

## Testing
- `npm test` *(fails: waiting for `.category` selector)*

------
https://chatgpt.com/codex/tasks/task_e_6848ddf174088321ac2da61870f0e18d