### PR TITLE
Update documentation references for script.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Some browsers restrict `fetch` when using the `file://` protocol. If the links d
 python3 -m http.server 3000
 ```
 
-Then visit `http://localhost:3000/index.html` in your browser. `main.js` fetches `links.json` at page load and dynamically builds the categorized link lists.
+Then visit `http://localhost:3000/index.html` in your browser. `script.js` fetches `links.json` at page load and dynamically builds the categorized link lists.
 
 ## Manual QA
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ps2links",
   "version": "1.0.0",
   "description": "PS2 Resource Links is a static collection of PlayStation 2 related sites. The page is built from `links.json` and displayed with simple JavaScript and CSS.",
-  "main": "main.js",
+  "main": "script.js",
   "scripts": {
     "test": "playwright test --config=tests/playwright.config.js"
   },


### PR DESCRIPTION
## Summary
- replace `main.js` with `script.js` in README instructions
- update `main` entry in `package.json`

## Testing
- `npm install`
- `npx playwright install` *(fails: host system missing dependencies)*
- `npm test` *(fails: waiting for `.category` selector)*

------
https://chatgpt.com/codex/tasks/task_e_6848df436fa08321b4d410a107c5870b