### PR TITLE
Fix search tags line

### DIFF
--- a/script.js
+++ b/script.js
@@ -186,8 +186,8 @@ function setupSearch() {
             const tagsSpan = button.querySelector('.service-tags');
             let tagsMatch = false;
             if (tagsSpan && tagsSpan.textContent) {
-                const tagsArray = tagsSpan.textContent.toLowerCase().split(',').
-map(tag => tag.trim());                tagsMatch = tagsArray.some(tag => tag.includes(query));
+                const tagsArray = tagsSpan.textContent.toLowerCase().split(',').map(tag => tag.trim());
+                tagsMatch = tagsArray.some(tag => tag.includes(query));
             }
             button.style.display = (name.includes(query) || url.includes(query)|| tagsMatch) ? 'flex' : 'none';
         });


### PR DESCRIPTION
## Summary
- keep tag parsing chain on one line in the search handler

## Testing
- `npm install`
- `npx playwright install`
- `npm test` *(fails: 2 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6848faf924cc8321af2ba1162ca786ac