### PR TITLE
Enable install button by default

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,25 +26,29 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const installBtn = document.getElementById('installBtn');
     if (installBtn) {
-        installBtn.style.display = 'none';
+        installBtn.disabled = true;
+        installBtn.title = 'Install becomes available when supported by your browser.';
         installBtn.addEventListener('click', async () => {
             if (!deferredPrompt) return;
             deferredPrompt.prompt();
             await deferredPrompt.userChoice;
             deferredPrompt = null;
-            installBtn.style.display = 'none';
+            installBtn.disabled = true;
+            installBtn.title = 'Install is not currently available.';
         });
     }
     window.addEventListener('beforeinstallprompt', (e) => {
         e.preventDefault();
         deferredPrompt = e;
         if (installBtn) {
-            installBtn.style.display = 'inline-block';
+            installBtn.disabled = false;
+            installBtn.removeAttribute('title');
         }
     });
     window.addEventListener('appinstalled', () => {
         if (installBtn) {
-            installBtn.style.display = 'none';
+            installBtn.disabled = true;
+            installBtn.title = 'App is installed';
         }
         deferredPrompt = null;
     });

--- a/styles.css
+++ b/styles.css
@@ -91,7 +91,12 @@ header {
     cursor: pointer;
     margin-top: 1rem;
     margin-left: 0.5rem;
-    display: none;
+    display: inline-block;
+}
+
+#installBtn[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 #clearFavoritesBtn {


### PR DESCRIPTION
## Summary
- display Install button but keep it disabled until the `beforeinstallprompt` event
- style Install button when disabled

## Testing
- `npm install`
- `npx playwright install`
- `npx http-server -p 3000 &`
- `npm test` *(fails: Search filters services and categories)*

------
https://chatgpt.com/codex/tasks/task_e_6849487504248321a0449a2c68c826f8