### PR TITLE
Add webServer option for Playwright tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm install
 npm test
 ```
 
-The tests start a local server automatically and cover view toggling, theme switching, and favorites persistence.
+The tests start a local server automatically by running `npx http-server -p 3000` before executing the test suite. They cover view toggling, theme switching, and favorites persistence.
 
 
 ## License

--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -19,4 +19,10 @@ module.exports = defineConfig({
     },
     // Add other browser configurations if needed
   ],
+  webServer: {
+    command: 'npx http-server -p 3000',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
 });


### PR DESCRIPTION
## Summary
- start an http-server before running Playwright tests
- document the automatic server in the README

## Testing
- `npm test` *(fails: Page title and header selector not found)*

------
https://chatgpt.com/codex/tasks/task_e_684949e0fa68832189194453d3e747ce