### PR TITLE
feat: Apply PS2 theme, fix sidebar toggle, and update favicons

### DIFF
--- a/links.json
+++ b/links.json
@@ -5,111 +5,138 @@
     "links": [
       {
         "name": "8BitMods Discord Server",
-        "url": "https://discord.gg/F2aKahj"
+        "url": "https://discord.gg/F2aKahj",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Fileforums.com",
-        "url": "https://fileforums.com/index.php"
+        "url": "https://fileforums.com/index.php",
+        "favicon_url": "https://fileforums.com/favicon.ico"
       },
       {
         "name": "GBATemp's PS2 Forum",
-        "url": "https://gbatemp.net/forums/other-platforms-oldies.202/?prefix_id=61"
+        "url": "https://gbatemp.net/forums/other-platforms-oldies.202/?prefix_id=61",
+        "favicon_url": "https://gbatemp.net/favicon.ico"
       },
       {
         "name": "Hardlevel Discord Server",
-        "url": "https://bit.ly/hardlevel-discord"
+        "url": "https://bit.ly/hardlevel-discord",
+        "favicon_url": "https://bit.ly/favicon.ico"
       },
       {
         "name": "NFOHump Forum",
-        "url": "https://www.nfohump.com/forum/index.php"
+        "url": "https://www.nfohump.com/forum/index.php",
+        "favicon_url": "https://www.nfohump.com/favicon.ico"
       },
       {
         "name": "Obscure Gamers Discord Server",
-        "url": "https://discord.gg/pJ8Qu7qYHX"
+        "url": "https://discord.gg/pJ8Qu7qYHX",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "OnlineConsole's PS2 Pages",
-        "url": "https://playstation2.onlineconsoles.com/phpBB2/index.php"
+        "url": "https://playstation2.onlineconsoles.com/phpBB2/index.php",
+        "favicon_url": "https://playstation2.onlineconsoles.com/favicon.ico"
       },
       {
         "name": "Playstation 2 Homebrew Community Discord Server (Archive)",
-        "url": "https://discord.gg/XaztguU"
+        "url": "https://discord.gg/XaztguU",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Playstation Homebrew Discord Server",
-        "url": "https://discord.gg/qHn9fuTrJw"
+        "url": "https://discord.gg/qHn9fuTrJw",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PS Gamers",
-        "url": "https://www.ps-gamers.ru/"
+        "url": "https://www.ps-gamers.ru/",
+        "favicon_url": "https://www.ps-gamers.ru/favicon.ico"
       },
       {
         "name": "PS-Gamers.ru Official Discord Server",
-        "url": "https://discord.gg/2V6SesJ"
+        "url": "https://discord.gg/2V6SesJ",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PS2 Homebrew Reddit",
-        "url": "https://www.reddit.com/r/ps2homebrew/"
+        "url": "https://www.reddit.com/r/ps2homebrew/",
+        "favicon_url": "https://www.reddit.com/favicon.ico"
       },
       {
         "name": "PS2 Reddit",
-        "url": "https://www.reddit.com/r/ps2/"
+        "url": "https://www.reddit.com/r/ps2/",
+        "favicon_url": "https://www.reddit.com/favicon.ico"
       },
       {
         "name": "PS2 Scene Discord Server",
-        "url": "https://discord.gg/ZH55QuTSfT"
+        "url": "https://discord.gg/ZH55QuTSfT",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PS2 Space Discord Server",
-        "url": "https://discord.gg/3SWDtuVy7r"
+        "url": "https://discord.gg/3SWDtuVy7r",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PS2-Home",
-        "url": "https://www.ps2-home.com/"
+        "url": "https://www.ps2-home.com/",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "PSX-Place",
-        "url": "https://www.psx-place.com/"
+        "url": "https://www.psx-place.com/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PSX-Place Discord Server",
-        "url": "https://discord.com/invite/kASwQBs5"
+        "url": "https://discord.com/invite/kASwQBs5",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "PSX-Place's PS2 Forums/Messaging Boards",
-        "url": "https://www.psx-place.com/forums/#playstation-2-forums.6"
+        "url": "https://www.psx-place.com/forums/#playstation-2-forums.6",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Retro Game Boards",
-        "url": "https://www.retrogameboards.com/"
+        "url": "https://www.retrogameboards.com/",
+        "favicon_url": "https://www.retrogameboards.com/favicon.ico"
       },
       {
         "name": "Romhacking.net Forum",
-        "url": "https://www.romhacking.net/forum/"
+        "url": "https://www.romhacking.net/forum/",
+        "favicon_url": "https://www.romhacking.net/favicon.ico"
       },
       {
         "name": "Romstation.fr Forum",
-        "url": "https://www.romstation.fr/forums/forum/376-forum"
+        "url": "https://www.romstation.fr/forums/forum/376-forum",
+        "favicon_url": "https://www.romstation.fr/favicon.ico"
       },
       {
         "name": "The Cutting Room Floor Discord Server",
-        "url": "https://discord.com/invite/SGeE8dcWR6"
+        "url": "https://discord.com/invite/SGeE8dcWR6",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "The Cutting Room Floor Message Boards",
-        "url": "https://jul.rustedlogic.net/forum.php?id=12"
+        "url": "https://jul.rustedlogic.net/forum.php?id=12",
+        "favicon_url": "https://jul.rustedlogic.net/favicon.ico"
       },
       {
         "name": "The Emotion Engine Nostalgia Extrusion Concern, LLC Discord Server",
-        "url": "https://discord.gg/GyZgHhpxXT"
+        "url": "https://discord.gg/GyZgHhpxXT",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "VGBA Forums",
-        "url": "https://vgboxart.com/forums/"
+        "url": "https://vgboxart.com/forums/",
+        "favicon_url": "https://vgboxart.com/favicon.ico"
       },
       {
         "name": "Xtreme Elite Boot+ Discord Server",
-        "url": "https://discord.com/invite/CnPWqBkAPG"
+        "url": "https://discord.com/invite/CnPWqBkAPG",
+        "favicon_url": "https://discord.com/favicon.ico"
       }
     ]
   },
@@ -119,115 +146,143 @@
     "links": [
       {
         "name": "25 to Life: Classic Discord Server",
-        "url": "https://discord.gg/gmYe84eS7q"
+        "url": "https://discord.gg/gmYe84eS7q",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Auto Modellista Meetup Club Discord Server",
-        "url": "https://discord.gg/h7RbJ5FCct"
+        "url": "https://discord.gg/h7RbJ5FCct",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Burnout 3 Online Revival Discord Server",
-        "url": "https://discord.gg/y9KYVrhQG7"
+        "url": "https://discord.gg/y9KYVrhQG7",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Burnout PS2 Online Discord Server",
-        "url": "https://discord.gg/cjceKbhuuv"
+        "url": "https://discord.gg/cjceKbhuuv",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "EQOA Revival Discord Server",
-        "url": "https://discord.gg/uwqdv9yKtH"
+        "url": "https://discord.gg/uwqdv9yKtH",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Jak & Daxter Fandom Wiki",
-        "url": "https://jakanddaxter.fandom.com/"
+        "url": "https://jakanddaxter.fandom.com/",
+        "favicon_url": "https://jakanddaxter.fandom.com/favicon.ico"
       },
       {
         "name": "Jack and Daxter Discord Server",
-        "url": "https://discord.gg/N358k7R"
+        "url": "https://discord.gg/N358k7R",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Jack and Daxter Lore'n'Lounge Discord Server",
-        "url": "https://discord.gg/RYJPuXkHu4"
+        "url": "https://discord.gg/RYJPuXkHu4",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Jack and Daxter Speedrun Discord Server",
-        "url": "https://discord.gg/UPaQy8ZUAa"
+        "url": "https://discord.gg/UPaQy8ZUAa",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Jak X Multiplayer Discord Server",
-        "url": "https://discord.gg/5VHj8sD"
+        "url": "https://discord.gg/5VHj8sD",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Medal of Honor Rising Discord Server",
-        "url": "https://discord.gg/2MafefE4XH"
+        "url": "https://discord.gg/2MafefE4XH",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "MH Oldschool Discord Server",
-        "url": "https://discord.gg/k7d6RKd"
+        "url": "https://discord.gg/k7d6RKd",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Midnight Club 3/2/L.A Online Official Discord Server",
-        "url": "https://discord.gg/Zfj4TYN"
+        "url": "https://discord.gg/Zfj4TYN",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Naughty Dog (Fan Server)",
-        "url": "https://discord.gg/tykmvRP"
+        "url": "https://discord.gg/tykmvRP",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Netslum - .hack//fragment Community Discord Server",
-        "url": "https://discord.gg/DY3XEe8"
+        "url": "https://discord.gg/DY3XEe8",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "NFSOR (NeedForSpeed) Discord Server",
-        "url": "https://discord.com/invite/3chzV4BMFn"
+        "url": "https://discord.com/invite/3chzV4BMFn",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "Ratchet & Clank 3 Casuals Discord Server",
-        "url": "https://discord.gg/S7h4SbzvyG"
+        "url": "https://discord.gg/S7h4SbzvyG",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Ratchet & Clank Discord Server",
-        "url": "https://discord.gg/UyAeTgJ"
+        "url": "https://discord.gg/UyAeTgJ",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Ratchet & Clank Horizon Online Play Discord Server",
-        "url": "https://discord.gg/KaqEVBuCUh"
+        "url": "https://discord.gg/KaqEVBuCUh",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Ratchet & Clank Online Discord Server",
-        "url": "https://discord.gg/mUQzqGu"
+        "url": "https://discord.gg/mUQzqGu",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Ratchet & Clank Size Matters Online Discord Server",
-        "url": "https://discord.gg/hD23nTfDxT"
+        "url": "https://discord.gg/hD23nTfDxT",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Save MGO Discord Server",
-        "url": "https://discord.com/invite/h5gA3X9Zhj"
+        "url": "https://discord.com/invite/h5gA3X9Zhj",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "SlyCooper Discord Server",
-        "url": "https://discord.gg/ZSjCVt2DNQ"
+        "url": "https://discord.gg/ZSjCVt2DNQ",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "SOCOM Community Discord Server",
-        "url": "https://discord.gg/HB33DqU"
+        "url": "https://discord.gg/HB33DqU",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Star Wars Battlefront PS2 Online Discord Server",
-        "url": "https://discord.gg/jQDPcTQurN"
+        "url": "https://discord.gg/jQDPcTQurN",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "SvR/WWE/F NETPLAY Discord Server",
-        "url": "https://discord.gg/Z6zqdDrKeT"
+        "url": "https://discord.gg/Z6zqdDrKeT",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Twisted Metal Alliance Discord Server",
-        "url": "https://discord.gg/hQbBHh3"
+        "url": "https://discord.gg/hQbBHh3",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "zdxsv (foreign Gundam) Discord Server",
-        "url": "https://discord.gg/NtnVPuvart"
+        "url": "https://discord.gg/NtnVPuvart",
+        "favicon_url": "https://discord.gg/favicon.ico"
       }
     ]
   },
@@ -237,403 +292,503 @@
     "links": [
       {
         "name": "AIO Project: PS2 v2.0.1 (2021) by Berion",
-        "url": "https://archive.org/details/aio-project-ps2-v201"
+        "url": "https://archive.org/details/aio-project-ps2-v201",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "Apollo Save Tool AIO Saves Management/Conversion/Import/Export",
-        "url": "https://github.com/bucanero/apollo-ps2"
+        "url": "https://github.com/bucanero/apollo-ps2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Arceus Menu by Project Zeus",
-        "url": "https://projectzeus0101.blogspot.com/"
+        "url": "https://projectzeus0101.blogspot.com/",
+        "favicon_url": "https://projectzeus0101.blogspot.com/favicon.ico"
       },
       {
         "name": "BDM Assault (enabled exFAT USB) by El_isra",
-        "url": "https://www.psx-place.com/threads/42352/"
+        "url": "https://www.psx-place.com/threads/42352/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "DKWDRV Batch Game Installer by GDX",
-        "url": "https://github.com/GDX-X/DKWDRV-Batch-Game-Installer"
+        "url": "https://github.com/GDX-X/DKWDRV-Batch-Game-Installer",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "ESR",
-        "url": "https://www.psx-place.com/resources/esr.951/update?update=1613"
+        "url": "https://www.psx-place.com/resources/esr.951/update?update=1613",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "FDVDB ESR Patcher GUI",
-        "url": "https://www.psx-place.com/threads/freedvdboot-by-cturt.30220/#post-255696"
+        "url": "https://www.psx-place.com/threads/freedvdboot-by-cturt.30220/#post-255696",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Fortuna Launcher",
-        "url": "https://github.com/Veritas83/PS2_FORTUNA_Launcher"
+        "url": "https://github.com/Veritas83/PS2_FORTUNA_Launcher",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "FreeDVDBoot Official github",
-        "url": "https://github.com/ps2homebrew/FreeDVDBoot"
+        "url": "https://github.com/ps2homebrew/FreeDVDBoot",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "FreeMCBoot Continued by El_isra",
-        "url": "https://israpps.github.io/FreeMcBoot-Installer/"
+        "url": "https://israpps.github.io/FreeMcBoot-Installer/",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "FreeMCBoot Official Page",
-        "url": "https://sites.google.com/view/ysai187/home/projects/fmcbfhdb"
+        "url": "https://sites.google.com/view/ysai187/home/projects/fmcbfhdb",
+        "favicon_url": "https://sites.google.com/favicon.ico"
       },
       {
         "name": "FTP Server for PS2",
-        "url": "https://github.com/ps2homebrew/ps2ftpd"
+        "url": "https://github.com/ps2homebrew/ps2ftpd",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "HDL Game Installer",
-        "url": "https://github.com/ps2homebrew/HDLGameInstaller"
+        "url": "https://github.com/ps2homebrew/HDLGameInstaller",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "HDL-Batch-Installer by El_isra",
-        "url": "https://israpps.github.io/HDL-Batch-installer/"
+        "url": "https://israpps.github.io/HDL-Batch-installer/",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "HDL_Dump",
-        "url": "https://github.com/ps2homebrew/hdl-dump"
+        "url": "https://github.com/ps2homebrew/hdl-dump",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Homebrew Downloader",
-        "url": "https://github.com/Veritas83/VTSPS2-HBDL"
+        "url": "https://github.com/Veritas83/VTSPS2-HBDL",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "KELFBINDER by El_isra",
-        "url": "https://israpps.github.io/KELFBinder/"
+        "url": "https://israpps.github.io/KELFBinder/",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "MCP2 OPL with Manual GameID Transmission",
-        "url": "https://install.appcenter.ms/orgs/beta-ucu9/apps/opl-with-gameid/distribution_groups/public"
+        "url": "https://install.appcenter.ms/orgs/beta-ucu9/apps/opl-with-gameid/distribution_groups/public",
+        "favicon_url": "https://install.appcenter.ms/favicon.ico"
       },
       {
         "name": "MECHAPWN",
-        "url": "https://github.com/MechaResearch/MechaPwn"
+        "url": "https://github.com/MechaResearch/MechaPwn",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Memory Card Annihilator (MCA) Memory Card Tool",
-        "url": "https://www.psx-place.com/threads/memory-card-annihilator-v2-0a-a-new-version-after-more-than-11-years.36277/"
+        "url": "https://www.psx-place.com/threads/memory-card-annihilator-v2-0a-a-new-version-after-more-than-11-years.36277/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "mymc Homepage",
-        "url": "http://www.csclub.uwaterloo.ca:11068/mymc/"
+        "url": "http://www.csclub.uwaterloo.ca:11068/mymc/",
+        "favicon_url": "http://www.csclub.uwaterloo.ca:11068/favicon.ico"
       },
       {
         "name": "mymcc github",
-        "url": "https://github.com/ps2dev/mymc"
+        "url": "https://github.com/ps2dev/mymc",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "mymcplus github",
-        "url": "https://github.com/thestr4ng3r/mymcplus"
+        "url": "https://github.com/thestr4ng3r/mymcplus",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "mymcplus Homepage",
-        "url": "https://git.sr.ht/~thestr4ng3r/mymcplus"
+        "url": "https://git.sr.ht/~thestr4ng3r/mymcplus",
+        "favicon_url": "https://git.sr.ht/favicon.ico"
       },
       {
         "name": "mymcplusplus github",
-        "url": "https://github.com/Adubbz/mymcplusplus"
+        "url": "https://github.com/Adubbz/mymcplusplus",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Neutrino",
-        "url": "https://github.com/rickgaiser/neutrino"
+        "url": "https://github.com/rickgaiser/neutrino",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Neutrino Loader XEB+ Plugin by sync-on-luma",
-        "url": "https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin"
+        "url": "https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "nHDDl Neutrino GUI PS2 Loader by pcm720",
-        "url": "https://github.com/pcm720/nhddl"
+        "url": "https://github.com/pcm720/nhddl",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader CFG Compatibility Databse by GDX",
-        "url": "https://github.com/GDX-X/PS2-OPL-CFG-Compatibility-Database"
+        "url": "https://github.com/GDX-X/PS2-OPL-CFG-Compatibility-Database",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader for PSX DVR DESR consoles",
-        "url": "https://github.com/SvenGDK/Open-PS2-Loader"
+        "url": "https://github.com/SvenGDK/Open-PS2-Loader",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Frontend for Neutrino",
-        "url": "https://www.psx-place.com/threads/opl-based-gui-frontend-for-neutrino.42166/"
+        "url": "https://www.psx-place.com/threads/opl-based-gui-frontend-for-neutrino.42166/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Official github - Official Downloads",
-        "url": "https://github.com/ps2homebrew/Open-PS2-Loader/releases"
+        "url": "https://github.com/ps2homebrew/Open-PS2-Loader/releases",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader OPLServer Windows SMB Program",
-        "url": "https://github.com/elmariolo/OPL-Server"
+        "url": "https://github.com/elmariolo/OPL-Server",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader PC Tools github Repo",
-        "url": "https://github.com/brainstream/OPL-PC-Tools"
+        "url": "https://github.com/brainstream/OPL-PC-Tools",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Samba (SMB) Server Docker",
-        "url": "https://github.com/milouk/docker-smb-opl"
+        "url": "https://github.com/milouk/docker-smb-opl",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Server Containerized",
-        "url": "https://github.com/marcosatti/ps2smb-server"
+        "url": "https://github.com/marcosatti/ps2smb-server",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Server Script",
-        "url": "https://github.com/Lumiazaine/PS2-SMB"
+        "url": "https://github.com/Lumiazaine/PS2-SMB",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Theme Editor (WYSIWYG)",
-        "url": "https://github.com/IcySon55/OPL-Theme-Editor"
+        "url": "https://github.com/IcySon55/OPL-Theme-Editor",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader UDPBD",
-        "url": "https://www.psx-place.com/threads/testers-needed-udpbd-the-next-generation-of-loading-games-through-lan-on-a-ps2.40132/"
+        "url": "https://www.psx-place.com/threads/testers-needed-udpbd-the-next-generation-of-loading-games-through-lan-on-a-ps2.40132/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Version Archive",
-        "url": "https://www.psx-place.com/resources/opl-archive.1447/"
+        "url": "https://www.psx-place.com/resources/opl-archive.1447/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "OpenTuna Installer Official Page",
-        "url": "https://github.com/ps2homebrew/opentuna-installer"
+        "url": "https://github.com/ps2homebrew/opentuna-installer",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "OPL Launcher",
-        "url": "https://github.com/ps2homebrew/OPL-Launcher"
+        "url": "https://github.com/ps2homebrew/OPL-Launcher",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "OPL Manager (OPLM) PC Application",
-        "url": "https://oplmanager.com/site/"
+        "url": "https://oplmanager.com/site/",
+        "favicon_url": "https://oplmanager.com/favicon.ico"
       },
       {
         "name": "OPL Scanner",
-        "url": "https://www.psx-place.com/threads/opl-scanner.42787/"
+        "url": "https://www.psx-place.com/threads/opl-scanner.42787/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "OPLUtil OPL Tool",
-        "url": "https://github.com/IsseiYoshida/OPLUtil"
+        "url": "https://github.com/IsseiYoshida/OPLUtil",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Original Memory Card Tester",
-        "url": "https://www.psx-place.com/resources/original-card-test.1504/"
+        "url": "https://www.psx-place.com/resources/original-card-test.1504/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "OSDSYS Launcher",
-        "url": "https://github.com/HowlingWolfHWC/OSDSYS-Launcher"
+        "url": "https://github.com/HowlingWolfHWC/OSDSYS-Launcher",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PFS-BatchKit-Manager by GDX",
-        "url": "https://github.com/GDX-X/PFS-BatchKit-Manager"
+        "url": "https://github.com/GDX-X/PFS-BatchKit-Manager",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PFS-BatchKit-Manager Extras by GDX",
-        "url": "https://www.mediafire.com/folder/mjrpskskupuvc/PS2"
+        "url": "https://www.mediafire.com/folder/mjrpskskupuvc/PS2",
+        "favicon_url": "https://www.mediafire.com/favicon.ico"
       },
       {
         "name": "Playstation 2 Basic Boot Loader by El_isra",
-        "url": "https://israpps.github.io/PlayStation2-Basic-BootLoader/"
+        "url": "https://israpps.github.io/PlayStation2-Basic-BootLoader/",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "PlayStation 2 MECHACON Adjustment Program (PMAP)",
-        "url": "https://www.psx-place.com/resources/playstation-2-mechacon-adjustment-program-pmap.962/"
+        "url": "https://www.psx-place.com/resources/playstation-2-mechacon-adjustment-program-pmap.962/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PlayStation Disc Burner (PSDB) by alex-free",
-        "url": "https://alex-free.github.io/psdb/"
+        "url": "https://alex-free.github.io/psdb/",
+        "favicon_url": "https://alex-free.github.io/favicon.ico"
       },
       {
         "name": "POPS VCD Manager by El_isra",
-        "url": "https://www.psx-place.com/resources/pops-vcd-manager.1284/"
+        "url": "https://www.psx-place.com/resources/pops-vcd-manager.1284/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPS2APPS",
-        "url": "https://www.psx-place.com/resources/pops2apps.1214/"
+        "url": "https://www.psx-place.com/resources/pops2apps.1214/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPSLoader by El_isra",
-        "url": "https://www.psx-place.com/resources/popsloader.1396/"
+        "url": "https://www.psx-place.com/resources/popsloader.1396/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPSTARTER Cumulative r6 Fixes",
-        "url": "https://www.psx-place.com/threads/popstarter.19139/page-5#post-254888"
+        "url": "https://www.psx-place.com/threads/popstarter.19139/page-5#post-254888",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPSTARTER Discs_Pooper for Auto creation DISCS.TXT and VMCDIR.TXT",
-        "url": "https://www.psx-place.com/resources/discs_pooper-bambuch0-fix.1429/"
+        "url": "https://www.psx-place.com/resources/discs_pooper-bambuch0-fix.1429/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPSTARTER Game Installer for OPL",
-        "url": "https://www.psx-place.com/threads/popstarter-game-installer-for-opl.34243/"
+        "url": "https://www.psx-place.com/threads/popstarter-game-installer-for-opl.34243/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPSTARTER Installer github (dated)",
-        "url": "https://github.com/IsseiYoshida/Instalador-POPStarter"
+        "url": "https://github.com/IsseiYoshida/Instalador-POPStarter",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "POPSTARTER Official Release and Resources Thread",
-        "url": "https://www.psx-place.com/threads/popstarter.19139/"
+        "url": "https://www.psx-place.com/threads/popstarter.19139/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "POPSY-X XEB+ PS1 Launcher by GDX",
-        "url": "https://www.psx-place.com/resources/popsy-x.1424/"
+        "url": "https://www.psx-place.com/resources/popsy-x.1424/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PS2 Bios Dumper",
-        "url": "https://github.com/F0bes/biosdrain"
+        "url": "https://github.com/F0bes/biosdrain",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Boot Sequencer for 900xx FMCB Remote Loading",
-        "url": "https://github.com/smsry/PS2-Boot-Sequencer"
+        "url": "https://github.com/smsry/PS2-Boot-Sequencer",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Controller Tester",
-        "url": "https://www.psx-place.com/resources/ps2-controller-tester-by-jbit.670/"
+        "url": "https://www.psx-place.com/resources/ps2-controller-tester-by-jbit.670/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PS2 Dummy ISO Creator",
-        "url": "https://www.mediafire.com/file/1j2obwq0v4d9rq4/%255BBlog_do_UsagiRu%255D_PS2_Dummy_Creator.zip/file"
+        "url": "https://www.mediafire.com/file/1j2obwq0v4d9rq4/%255BBlog_do_UsagiRu%255D_PS2_Dummy_Creator.zip/file",
+        "favicon_url": "https://www.mediafire.com/favicon.ico"
       },
       {
         "name": "PS2 Icon Sys Tools",
-        "url": "https://github.com/ticky/ps2iconsys"
+        "url": "https://github.com/ticky/ps2iconsys",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Image Maker for PS2 iso files",
-        "url": "https://github.com/Smartkin/PS2ImageMaker"
+        "url": "https://github.com/Smartkin/PS2ImageMaker",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 ISO Batch Renamer",
-        "url": "https://github.com/L10N37/PS2-ISO-Batch-Renamer-"
+        "url": "https://github.com/L10N37/PS2-ISO-Batch-Renamer-",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 ISO Tools - Read, Build, Edit PS2 ISOs with UDF Filesystem",
-        "url": "https://github.com/Finzenku/Ps2IsoTools"
+        "url": "https://github.com/Finzenku/Ps2IsoTools",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 MC Browser",
-        "url": "https://github.com/caol64/ps2mc-browser"
+        "url": "https://github.com/caol64/ps2mc-browser",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Save Decrypters by bucanero",
-        "url": "https://github.com/bucanero/save-decrypters"
+        "url": "https://github.com/bucanero/save-decrypters",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Save Utility Converter for Save Files",
-        "url": "https://github.com/root670/PS2SaveUtility"
+        "url": "https://github.com/root670/PS2SaveUtility",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Splash for Custom PNG Splash image on OSDSYS Launcher",
-        "url": "https://github.com/parrado/ps2splash"
+        "url": "https://github.com/parrado/ps2splash",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 VMC Tool by bucanero",
-        "url": "https://github.com/bucanero/ps2vmc-tool"
+        "url": "https://github.com/bucanero/ps2vmc-tool",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2-VMC-GUI",
-        "url": "https://github.com/MegaBitmap/PS2-VMC-GUI"
+        "url": "https://github.com/MegaBitmap/PS2-VMC-GUI",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2-Yabasic-Exploit",
-        "url": "https://github.com/CTurt/PS2-Yabasic-Exploit"
+        "url": "https://github.com/CTurt/PS2-Yabasic-Exploit",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2Ident PS2 Identification Homebrew",
-        "url": "https://github.com/ps2homebrew/PS2Ident"
+        "url": "https://github.com/ps2homebrew/PS2Ident",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS3 MCA Exploit",
-        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=297"
+        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=297",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "PS3 MCA Exploit Archive",
-        "url": "https://web.archive.org/web/20241121005548/https://www.ps2-home.com/forum/viewtopic.php?t=297"
+        "url": "https://web.archive.org/web/20241121005548/https://www.ps2-home.com/forum/viewtopic.php?t=297",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "PSCOVERDL tool for PCSX2 and Duckstation Cover Art",
-        "url": "https://github.com/xlenore/pscoverdl"
+        "url": "https://github.com/xlenore/pscoverdl",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PSX DVR DESR Tools github",
-        "url": "https://github.com/SvenGDK/DESR-Tools"
+        "url": "https://github.com/SvenGDK/DESR-Tools",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PSX-XMB-Manager Homebrew Installer for the PSX DVR (DESR)",
-        "url": "https://github.com/SvenGDK/PSX-XMB-Manager"
+        "url": "https://github.com/SvenGDK/PSX-XMB-Manager",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PSXVCD Tool",
-        "url": "https://www.psx-place.com/resources/psxvcd.669/"
+        "url": "https://www.psx-place.com/resources/psxvcd.669/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "pypsu Library for analyzing/creating PS2 PSu Saves",
-        "url": "https://github.com/McCaulay/pypsu"
+        "url": "https://github.com/McCaulay/pypsu",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Radhost Client",
-        "url": "https://www.psx-place.com/resources/rad-host-client-1-8a-sms-ule-host-compatible.629/"
+        "url": "https://www.psx-place.com/resources/rad-host-client-1-8a-sms-ule-host-compatible.629/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "RETRO Gem Programs/Applications/Game ID by CosmicScale",
-        "url": "https://github.com/CosmicScale?tab=repositories"
+        "url": "https://github.com/CosmicScale?tab=repositories",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "RETROLauncher by Spaghetticode (Boon Tobias)",
-        "url": "https://github.com/Spaghetticode-Boon-Tobias/RETROLauncher"
+        "url": "https://github.com/Spaghetticode-Boon-Tobias/RETROLauncher",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "SAS .psu Releases/Downloads Index",
-        "url": "https://app.filen.io/#/f/979a8ea4-5556-4d55-bee8-c9329c463db6#sUFLyL85q45reUqcrrazZWktYK0pHjk6"
+        "url": "https://app.filen.io/#/f/979a8ea4-5556-4d55-bee8-c9329c463db6#sUFLyL85q45reUqcrrazZWktYK0pHjk6",
+        "favicon_url": "https://app.filen.io/favicon.ico"
       },
       {
         "name": "Simple Media System (SMS)",
-        "url": "https://github.com/ps2homebrew/SMS"
+        "url": "https://github.com/ps2homebrew/SMS",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "smbLaunchELF",
-        "url": "https://www.psx-place.com/resources/smblaunchelf.1190/"
+        "url": "https://www.psx-place.com/resources/smblaunchelf.1190/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Tony Hawk's Pro Strcpy Exploit by Grimdoomer",
-        "url": "https://github.com/grimdoomer/TonyHawksProStrcpy"
+        "url": "https://github.com/grimdoomer/TonyHawksProStrcpy",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Tonyhax International by Alex-free",
-        "url": "https://alex-free.github.io/tonyhax-international/"
+        "url": "https://alex-free.github.io/tonyhax-international/",
+        "favicon_url": "https://alex-free.github.io/favicon.ico"
       },
       {
         "name": "unofficial Open PS2 Loader Grimdoomer internal exFAT Forked Version",
-        "url": "https://github.com/grimdoomer/Open-PS2-Loader/releases"
+        "url": "https://github.com/grimdoomer/Open-PS2-Loader/releases",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "unofficial Open PS2 Loader Tenth Anniversary Edition Daily Build by Jay-Jay (Not recommended and abandoned)",
-        "url": "https://github.com/Jay-Jay-OPL/OPL-Daily-Builds"
+        "url": "https://github.com/Jay-Jay-OPL/OPL-Daily-Builds",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "USBUtil for Splitting ISO Files on fat32 USB for OPL",
-        "url": "https://www.psx-place.com/threads/usbutil-by-iseko.19048/#post-397442"
+        "url": "https://www.psx-place.com/threads/usbutil-by-iseko.19048/#post-397442",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "VMC Bootcard Loader MOD by El_isra",
-        "url": "https://github.com/israpps/bootcard_igr"
+        "url": "https://github.com/israpps/bootcard_igr",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "wLaunchELF_isr Downloads Page by El_isra",
-        "url": "https://israpps.github.io/projects/wlaunchelf-isr"
+        "url": "https://israpps.github.io/projects/wlaunchelf-isr",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "wLaunchELF_isr_HDD (Injection Capable) Project Page",
-        "url": "https://github.com/israpps/wLaunchELF_ISR_HDD"
+        "url": "https://github.com/israpps/wLaunchELF_ISR_HDD",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Xtreme Elite Boot+ Homepage",
-        "url": "http://www.hwc.nat.cu/ps2-vault/hwc-projects/xebplus/"
+        "url": "http://www.hwc.nat.cu/ps2-vault/hwc-projects/xebplus/",
+        "favicon_url": "http://www.hwc.nat.cu/favicon.ico"
       },
       {
         "name": "Xtreme Elite Boot+ Mirror",
-        "url": "https://web.archive.org/web/20240729132341/http://www.hwc.nat.cu/ps2-vault/hwc-projects/xebplus/"
+        "url": "https://web.archive.org/web/20240729132341/http://www.hwc.nat.cu/ps2-vault/hwc-projects/xebplus/",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       }
     ]
   },
@@ -643,163 +798,203 @@
     "links": [
       {
         "name": "\"Dungeon\" test demo game",
-        "url": "https://bitbucket.org/glampert/ps2dev-tests/src/master/"
+        "url": "https://bitbucket.org/glampert/ps2dev-tests/src/master/",
+        "favicon_url": "https://bitbucket.org/favicon.ico"
       },
       {
         "name": "3D Pinball PS2",
-        "url": "https://github.com/headshot2017/3dpinball-ps2"
+        "url": "https://github.com/headshot2017/3dpinball-ps2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "AetherSX2 Emulator Discord Server",
-        "url": "https://discord.com/channels/914421153827794975/1063889680329879562"
+        "url": "https://discord.com/channels/914421153827794975/1063889680329879562",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "Athena Environment",
-        "url": "https://athena-env.vercel.app/"
+        "url": "https://athena-env.vercel.app/",
+        "favicon_url": "https://athena-env.vercel.app/favicon.ico"
       },
       {
         "name": "Athena PS2 System (AthenaEnv by DanielSant0s) Discord Server",
-        "url": "https://discord.gg/E7STQHQr9d"
+        "url": "https://discord.gg/E7STQHQr9d",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "AthenaEnv by DanielSant0s github",
-        "url": "https://github.com/DanielSant0s/AthenaEnv"
+        "url": "https://github.com/DanielSant0s/AthenaEnv",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "CosmicScale's github featuring Retro GEM Homebrews",
-        "url": "https://github.com/CosmicScale"
+        "url": "https://github.com/CosmicScale",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Discord for the PS2",
-        "url": "https://github.com/DanielSant0s/PS2Discord"
+        "url": "https://github.com/DanielSant0s/PS2Discord",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "DKWDRV Playstation 1 Driver for PS2",
-        "url": "https://github.com/DKWDRV"
+        "url": "https://github.com/DKWDRV",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "DobieStation",
-        "url": "https://github.com/PSI-Rockin/DobieStation"
+        "url": "https://github.com/PSI-Rockin/DobieStation",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Dungeon SDL2 Homebrew Game",
-        "url": "https://github.com/DevECoisas/PS2_Dungeon"
+        "url": "https://github.com/DevECoisas/PS2_Dungeon",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Enceladus by DanielSant0s github",
-        "url": "https://github.com/DanielSant0s/Enceladus"
+        "url": "https://github.com/DanielSant0s/Enceladus",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Ghidra EmotionEndgine Reloaded - Ghidra PS2 Addon",
-        "url": "https://github.com/chaoticgd/ghidra-emotionengine-reloaded"
+        "url": "https://github.com/chaoticgd/ghidra-emotionengine-reloaded",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Ghidra Processor definitions for MIPS R5900 (PS2)",
-        "url": "https://github.com/astrelsky/ghidra_MIPSR5900"
+        "url": "https://github.com/astrelsky/ghidra_MIPSR5900",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "GOG Galaxy 2.0 Integration for PS2",
-        "url": "https://github.com/AHCoder/galaxy-integration-ps2"
+        "url": "https://github.com/AHCoder/galaxy-integration-ps2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "HowlingWolfHWC's official github",
-        "url": "https://github.com/HowlingWolfHWC"
+        "url": "https://github.com/HowlingWolfHWC",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "KELFtool - decrypt, encrypt, and sign KELF files for PS2/1",
-        "url": "https://github.com/xfwcfw/kelftool"
+        "url": "https://github.com/xfwcfw/kelftool",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PCSX2 Emulator's Official Discord Server",
-        "url": "https://discord.com/invite/TCz3t9k"
+        "url": "https://discord.com/invite/TCz3t9k",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "PCSX2 Emulator's Official Site",
-        "url": "https://pcsx2.net/"
+        "url": "https://pcsx2.net/",
+        "favicon_url": "https://pcsx2.net/favicon.ico"
       },
       {
         "name": "PCSX2 Forums",
-        "url": "https://forums.pcsx2.net/"
+        "url": "https://forums.pcsx2.net/",
+        "favicon_url": "https://forums.pcsx2.net/favicon.ico"
       },
       {
         "name": "POPS Binaries",
-        "url": "https://github.com/AnimMouse/POPS-binaries"
+        "url": "https://github.com/AnimMouse/POPS-binaries",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Prussia",
-        "url": "https://github.com/Ravenslofty/prussia"
+        "url": "https://github.com/Ravenslofty/prussia",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Client",
-        "url": "https://github.com/ps2dev/ps2client"
+        "url": "https://github.com/ps2dev/ps2client",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Debugging Toolset",
-        "url": "https://github.com/ps2dbg/dsnet"
+        "url": "https://github.com/ps2dbg/dsnet",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Developer github",
-        "url": "https://github.com/ps2dev"
+        "url": "https://github.com/ps2dev",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Disc Saver",
-        "url": "https://github.com/FloppidyDingo/PS2-Disk-Saver/wiki/Installation-Instructions"
+        "url": "https://github.com/FloppidyDingo/PS2-Disk-Saver/wiki/Installation-Instructions",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Drivers (.IRX EE .a)",
-        "url": "https://github.com/fjtrujy/ps2_drivers"
+        "url": "https://github.com/fjtrujy/ps2_drivers",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Homebrew github",
-        "url": "https://github.com/ps2homebrew"
+        "url": "https://github.com/ps2homebrew",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Link - Side Application Loader",
-        "url": "https://github.com/ps2dev/ps2link"
+        "url": "https://github.com/ps2dev/ps2link",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Packer - Homebrew ELF Compresser",
-        "url": "https://github.com/ps2dev/ps2-packer"
+        "url": "https://github.com/ps2dev/ps2-packer",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Unpacker - Homebrew ELF Decompresser",
-        "url": "https://github.com/ps2homebrew/ps2-unpacker"
+        "url": "https://github.com/ps2homebrew/ps2-unpacker",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2Runner Remote Test Harness for PS2 via IRToy and ps2link",
-        "url": "https://github.com/telyn/ps2runner"
+        "url": "https://github.com/telyn/ps2runner",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2SDK",
-        "url": "https://github.com/ps2dev/ps2sdk"
+        "url": "https://github.com/ps2dev/ps2sdk",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "RetroArch for the PS2",
-        "url": "https://docs.libretro.com/guides/install-ps2/"
+        "url": "https://docs.libretro.com/guides/install-ps2/",
+        "favicon_url": "https://docs.libretro.com/favicon.ico"
       },
       {
         "name": "SuperTux",
-        "url": "https://github.com/headshot2017/supertux-ps2"
+        "url": "https://github.com/headshot2017/supertux-ps2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Tyra",
-        "url": "https://github.com/h4570/tyra/"
+        "url": "https://github.com/h4570/tyra/",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "TyraCraft",
-        "url": "https://github.com/Wellinator/tyracraft"
+        "url": "https://github.com/Wellinator/tyracraft",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Undertale for the PS2",
-        "url": "https://github.com/KreitinnSoftware/Undertale-PS2"
+        "url": "https://github.com/KreitinnSoftware/Undertale-PS2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "XPF Tool for Extraction and Decompresson",
-        "url": "https://github.com/simontime/xpftool"
+        "url": "https://github.com/simontime/xpftool",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "ZigStation2",
-        "url": "https://github.com/FalsePattern/ZigStation2"
+        "url": "https://github.com/FalsePattern/ZigStation2",
+        "favicon_url": "https://github.com/favicon.ico"
       }
     ]
   },
@@ -809,291 +1004,363 @@
     "links": [
       {
         "name": "576p GSM",
-        "url": "https://github.com/sestain/gsm"
+        "url": "https://github.com/sestain/gsm",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Art and Info for OPL and XEB+",
-        "url": "https://github.com/HowlingWolfHWC/PS2-Art-and-Info-for-OPL-and-XEBPlus"
+        "url": "https://github.com/HowlingWolfHWC/PS2-Art-and-Info-for-OPL-and-XEBPlus",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Art DB Backups from OPLManager.com",
-        "url": "https://oplmanager.com/site/?backups"
+        "url": "https://oplmanager.com/site/?backups",
+        "favicon_url": "https://oplmanager.com/favicon.ico"
       },
       {
         "name": "Art Hi-Res Covers by Berion and Krahjohlito",
-        "url": "https://app.filen.io/#/d/84d32310-81e2-43c7-8d24-8c49ee281780#FOGFf1breawlIAm4qFvQSw2AIcymlwo4"
+        "url": "https://app.filen.io/#/d/84d32310-81e2-43c7-8d24-8c49ee281780#FOGFf1breawlIAm4qFvQSw2AIcymlwo4",
+        "favicon_url": "https://app.filen.io/favicon.ico"
       },
       {
         "name": "Art NTSC Hi-Res 8bit for OPL",
-        "url": "https://www.mediafire.com/file/6vik1mdhtai4n48/NTSC_Hi-Res_8-bit.zip/file"
+        "url": "https://www.mediafire.com/file/6vik1mdhtai4n48/NTSC_Hi-Res_8-bit.zip/file",
+        "favicon_url": "https://www.mediafire.com/favicon.ico"
       },
       {
         "name": "Art NTSC Hi-Res 8bit for OPL (archive)",
-        "url": "https://archive.org/details/ntsc-hi-res-8-bit"
+        "url": "https://archive.org/details/ntsc-hi-res-8-bit",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "Assorted OPL Theme Relatted Documentation",
-        "url": "https://mega.nz/folder/h6kWwZKb#TitJOS1xFjKBP9tHDA7c3Q"
+        "url": "https://mega.nz/folder/h6kWwZKb#TitJOS1xFjKBP9tHDA7c3Q",
+        "favicon_url": "https://mega.nz/favicon.ico"
       },
       {
         "name": "BarbudimGamer's youtube OPL Themes",
-        "url": "https://www.youtube.com/@BarbudimGamer/search?query=JVSG"
+        "url": "https://www.youtube.com/@BarbudimGamer/search?query=JVSG",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "bin2code convert binaries into PS2 Cheats",
-        "url": "https://github.com/Dnawrkshp/bin2code"
+        "url": "https://github.com/Dnawrkshp/bin2code",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Cheat Database Launcher",
-        "url": "https://www.psx-place.com/resources/cheat-database-launcher.1500/"
+        "url": "https://www.psx-place.com/resources/cheat-database-launcher.1500/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Cheat Device",
-        "url": "https://israpps.github.io/CheatDevicePS2/"
+        "url": "https://israpps.github.io/CheatDevicePS2/",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "Cheat Engine Website",
-        "url": "http://www.cheatengine.org/"
+        "url": "http://www.cheatengine.org/",
+        "favicon_url": "http://www.cheatengine.org/favicon.ico"
       },
       {
         "name": "CodeBreaker PS2 File Utility",
-        "url": "https://github.com/mlafeldt/cb2util"
+        "url": "https://github.com/mlafeldt/cb2util",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Controversas Nerds's youtube OPL Themes",
-        "url": "https://youtube.com/playlist?list=PLYa7yhJPUuTWTbnVNZXYvyonCYneyG4-z&si=U6UJkMiwviLC9xDi"
+        "url": "https://youtube.com/playlist?list=PLYa7yhJPUuTWTbnVNZXYvyonCYneyG4-z&si=U6UJkMiwviLC9xDi",
+        "favicon_url": "https://youtube.com/favicon.ico"
       },
       {
         "name": "Cover Database by SvenGDK",
-        "url": "https://github.com/SvenGDK/PSMT-Covers"
+        "url": "https://github.com/SvenGDK/PSMT-Covers",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Cover Scans by Video Game Museum",
-        "url": "https://www.vgmuseum.com/scans/ps2.html"
+        "url": "https://www.vgmuseum.com/scans/ps2.html",
+        "favicon_url": "https://www.vgmuseum.com/favicon.ico"
       },
       {
         "name": "Cover Target Game Covers",
-        "url": "https://covertarget.com/"
+        "url": "https://covertarget.com/",
+        "favicon_url": "https://covertarget.com/favicon.ico"
       },
       {
         "name": "Covers by Kirkland's MANUAL LABOR",
-        "url": "http://www.atensionspan.com/evil/tn/index.html"
+        "url": "http://www.atensionspan.com/evil/tn/index.html",
+        "favicon_url": "http://www.atensionspan.com/favicon.ico"
       },
       {
         "name": "Covers by Kirkland's MANUAL LABOR (evilbadman.com archive)",
-        "url": "https://web.archive.org/web/20231129120159/http://evilbadman.com/"
+        "url": "https://web.archive.org/web/20231129120159/http://evilbadman.com/",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Covers by Kirkland's Manual Labor 4k PS2 Archive",
-        "url": "https://archive.org/details/kirklands-manual-labor-sony-playstation-2-usa-4k-version"
+        "url": "https://archive.org/details/kirklands-manual-labor-sony-playstation-2-usa-4k-version",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "Covers by LaunchBox Community Forums - Ultra HD",
-        "url": "https://forums.launchbox-app.com/files/category/187-sony-playstation-2/"
+        "url": "https://forums.launchbox-app.com/files/category/187-sony-playstation-2/",
+        "favicon_url": "https://forums.launchbox-app.com/favicon.ico"
       },
       {
         "name": "Crymax's blogspot OPL Themes",
-        "url": "https://crymaax.blogspot.com/"
+        "url": "https://crymaax.blogspot.com/",
+        "favicon_url": "https://crymaax.blogspot.com/favicon.ico"
       },
       {
         "name": "Crymax's youtube OPL Themes",
-        "url": "https://www.youtube.com/@CRYMAXPS2/search?query=OPL"
+        "url": "https://www.youtube.com/@CRYMAXPS2/search?query=OPL",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Cue Maker",
-        "url": "https://github.com/tralph3/Cue-Maker"
+        "url": "https://github.com/tralph3/Cue-Maker",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Dirty Cheater / Touffu's Site",
-        "url": "http://blog.goo.ne.jp/touffu"
+        "url": "http://blog.goo.ne.jp/touffu",
+        "favicon_url": "http://blog.goo.ne.jp/favicon.ico"
       },
       {
         "name": "DNAS Bypass Cheats",
-        "url": "https://www.psx-place.com/threads/tutorial-how-to-play-online-on-ps2-dvd-games-with-cheat-device-1-7-4.29802/"
+        "url": "https://www.psx-place.com/threads/tutorial-how-to-play-online-on-ps2-dvd-games-with-cheat-device-1-7-4.29802/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "DNAS Patcher output to PNACH File Converter",
-        "url": "https://github.com/VTSTech/DNAStoPNACH"
+        "url": "https://github.com/VTSTech/DNAStoPNACH",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "FEH e RICK OPL Theme Blog",
-        "url": "https://fehps2.blogspot.com/"
+        "url": "https://fehps2.blogspot.com/",
+        "favicon_url": "https://fehps2.blogspot.com/favicon.ico"
       },
       {
         "name": "Free Master Code Finder by El_isra",
-        "url": "https://github.com/israpps/FreeMastercodeFinder"
+        "url": "https://github.com/israpps/FreeMastercodeFinder",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "GaboGames's youtube OPL Themes",
-        "url": "https://youtube.com/playlist?list=PL59JnGTaT2IuezfrfgH7y7cgXudavQzwX&si=Quj_tI5xpRKzfq55"
+        "url": "https://youtube.com/playlist?list=PL59JnGTaT2IuezfrfgH7y7cgXudavQzwX&si=Quj_tI5xpRKzfq55",
+        "favicon_url": "https://youtube.com/favicon.ico"
       },
       {
         "name": "GaboGames's youtube OPL Themes missing",
-        "url": "https://www.youtube.com/@gabogamesbol/search?query=tema"
+        "url": "https://www.youtube.com/@gabogamesbol/search?query=tema",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Game Mods Collection by Nahelam",
-        "url": "https://github.com/Nahelam/PS2-Game-Mods"
+        "url": "https://github.com/Nahelam/PS2-Game-Mods",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "GameHacking.org - PS2",
-        "url": "https://gamehacking.org/system/ps2"
+        "url": "https://gamehacking.org/system/ps2",
+        "favicon_url": "https://gamehacking.org/favicon.ico"
       },
       {
         "name": "Gamehacking.org",
-        "url": "http://www.gamehacking.org/"
+        "url": "http://www.gamehacking.org/",
+        "favicon_url": "http://www.gamehacking.org/favicon.ico"
       },
       {
         "name": "gamerman 5000's OPL Theme Guide",
-        "url": "https://www.psx-place.com/threads/opl-theme-creation-manual.41893/"
+        "url": "https://www.psx-place.com/threads/opl-theme-creation-manual.41893/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "God-Hand-Tools for Conversion, Extraction, and Repacking",
-        "url": "https://github.com/akitotheanimator/God-Hand-Tools"
+        "url": "https://github.com/akitotheanimator/God-Hand-Tools",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "HQ HD Disc Case Covers by Berion",
-        "url": "https://www.psx-place.com/threads/hq-disc-case-covers.26545/"
+        "url": "https://www.psx-place.com/threads/hq-disc-case-covers.26545/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Leroy Gates's youtube OPL Themes",
-        "url": "https://www.youtube.com/@leroygates3239/search?query=Theme"
+        "url": "https://www.youtube.com/@leroygates3239/search?query=Theme",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Master Disc Patcher",
-        "url": "https://alex-free.github.io/psdb/master-disc.html"
+        "url": "https://alex-free.github.io/psdb/master-disc.html",
+        "favicon_url": "https://alex-free.github.io/favicon.ico"
       },
       {
         "name": "Mega.nz OPL Themes Package 1",
-        "url": "https://mega.nz/folder/onk0gLhY#FbmAnbQmyp3ZBd5Xf8_sMQ"
+        "url": "https://mega.nz/folder/onk0gLhY#FbmAnbQmyp3ZBd5Xf8_sMQ",
+        "favicon_url": "https://mega.nz/favicon.ico"
       },
       {
         "name": "Mega.nz OPL Themes Package 2",
-        "url": "https://mega.nz/folder/xudghTRZ#kLb6gl5cJhUTi4qK70qxYg"
+        "url": "https://mega.nz/folder/xudghTRZ#kLb6gl5cJhUTi4qK70qxYg",
+        "favicon_url": "https://mega.nz/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Widescreen Cheats",
-        "url": "https://github.com/PS2-Widescreen/OPL-Widescreen-Cheats"
+        "url": "https://github.com/PS2-Widescreen/OPL-Widescreen-Cheats",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Widescreen Cheats Collection (dated)",
-        "url": "https://github.com/madmodder123/OpenPS2Loader_Widescreen_Cheats"
+        "url": "https://github.com/madmodder123/OpenPS2Loader_Widescreen_Cheats",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "OPL Manager's OPL Simulator Themes Guide",
-        "url": "https://oplmanager.com/site/?docs#oplsimulator"
+        "url": "https://oplmanager.com/site/?docs#oplsimulator",
+        "favicon_url": "https://oplmanager.com/favicon.ico"
       },
       {
         "name": "OPLMania's blogspot OPL Themes",
-        "url": "https://oplmania.blogspot.com/2018/08/tema-ps2-plus-v1.html"
+        "url": "https://oplmania.blogspot.com/2018/08/tema-ps2-plus-v1.html",
+        "favicon_url": "https://oplmania.blogspot.com/favicon.ico"
       },
       {
         "name": "PCSX2 Cheats Collection github",
-        "url": "https://github.com/xs1l3n7x/pcsx2_cheats_collection"
+        "url": "https://github.com/xs1l3n7x/pcsx2_cheats_collection",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PixeliGer's github OPL Themes",
-        "url": "https://github.com/PixeliGer?tab=repositories"
+        "url": "https://github.com/PixeliGer?tab=repositories",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PPF Relatted Softwares and Information",
-        "url": "https://consolecopyworld.com/ps2/ps2_ppf.shtml"
+        "url": "https://consolecopyworld.com/ps2/ps2_ppf.shtml",
+        "favicon_url": "https://consolecopyworld.com/favicon.ico"
       },
       {
         "name": "PS1 HDMI/Component Fix for PS2 (custom GSM)",
-        "url": "https://github.com/PhilRoll/gsm"
+        "url": "https://github.com/PhilRoll/gsm",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 .PNACH Converter for OPL",
-        "url": "https://github.com/israpps/PS2-pnach-converter"
+        "url": "https://github.com/israpps/PS2-pnach-converter",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Covers github",
-        "url": "https://github.com/xlenore/ps2-covers"
+        "url": "https://github.com/xlenore/ps2-covers",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Patch Engine",
-        "url": "https://www.psx-place.com/threads/ps2-patch-engine-by-pelvicthrustman.19167/#post-130158"
+        "url": "https://www.psx-place.com/threads/ps2-patch-engine-by-pelvicthrustman.19167/#post-130158",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PS2 Patch Museum",
-        "url": "https://museudospatche.blogspot.com//"
+        "url": "https://museudospatche.blogspot.com//",
+        "favicon_url": "https://museudospatche.blogspot.com/favicon.ico"
       },
       {
         "name": "PS2-Home's OPL Themes",
-        "url": "https://www.ps2-home.com/forum/viewforum.php?f=51&sid=fcd3b52bdb73ea4c2573e11220a20dbd"
+        "url": "https://www.ps2-home.com/forum/viewforum.php?f=51&sid=fcd3b52bdb73ea4c2573e11220a20dbd",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "PS2-Home's OPL Themes (Archive)",
-        "url": "https://web.archive.org/web/20241122180419/https://www.ps2-home.com/forum/viewforum.php?f=51&sid=fcd3b52bdb73ea4c2573e11220a20dbd"
+        "url": "https://web.archive.org/web/20241122180419/https://www.ps2-home.com/forum/viewforum.php?f=51&sid=fcd3b52bdb73ea4c2573e11220a20dbd",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "PS2-Home's OPL Themes Guide",
-        "url": "https://www.ps2-home.com/forum/viewtopic.php?f=111&t=1782"
+        "url": "https://www.ps2-home.com/forum/viewtopic.php?f=111&t=1782",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "PS2-Home's OPL Themes Guide (Archive)",
-        "url": "https://web.archive.org/web/20241122180601/https://www.ps2-home.com/forum/viewtopic.php?f=111&t=1782"
+        "url": "https://web.archive.org/web/20241122180601/https://www.ps2-home.com/forum/viewtopic.php?f=111&t=1782",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "PS2infinity's blogspot OPL Themes",
-        "url": "https://ps2infinitymod.blogspot.com/"
+        "url": "https://ps2infinitymod.blogspot.com/",
+        "favicon_url": "https://ps2infinitymod.blogspot.com/favicon.ico"
       },
       {
         "name": "PS2THM's blogspot OPL Themes",
-        "url": "https://thmps2.blogspot.com/"
+        "url": "https://thmps2.blogspot.com/",
+        "favicon_url": "https://thmps2.blogspot.com/favicon.ico"
       },
       {
         "name": "PS2rd MOD",
-        "url": "https://www.psx-place.com/threads/ps2rdmod-by-pelvicthrustman.19168/"
+        "url": "https://www.psx-place.com/threads/ps2rdmod-by-pelvicthrustman.19168/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PS2rd PS2 Debugging Tools",
-        "url": "https://github.com/mlafeldt/ps2rd"
+        "url": "https://github.com/mlafeldt/ps2rd",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PSX-Place.com OPL Themes",
-        "url": "https://www.psx-place.com/forums/themes-for-opl.229/"
+        "url": "https://www.psx-place.com/forums/themes-for-opl.229/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Rockstar Games Uncensored PS2 Cheats",
-        "url": "https://github.com/GDX-X/Rockstar-Games-Uncensored-PS2"
+        "url": "https://github.com/GDX-X/Rockstar-Games-Uncensored-PS2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "ROM Hacking .net Homepage",
-        "url": "https://www.romhacking.net/"
+        "url": "https://www.romhacking.net/",
+        "favicon_url": "https://www.romhacking.net/favicon.ico"
       },
       {
         "name": "ShaolinAssassin's OPL Theme Guide",
-        "url": "https://web.archive.org/web/20200622004109/https://bitbucket.org/ShaolinAssassin/open-ps2-loader-0.9.3-documentation-project/wiki/theme-guide"
+        "url": "https://web.archive.org/web/20200622004109/https://bitbucket.org/ShaolinAssassin/open-ps2-loader-0.9.3-documentation-project/wiki/theme-guide",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Skinneblack's youtube OPL Themes",
-        "url": "https://youtube.com/playlist?list=PLxne_h-fAME2ZN-0LsFjKiGVTxXJAKoZC&si=N5hpgaSNm6TXWxiC"
+        "url": "https://youtube.com/playlist?list=PLxne_h-fAME2ZN-0LsFjKiGVTxXJAKoZC&si=N5hpgaSNm6TXWxiC",
+        "favicon_url": "https://youtube.com/favicon.ico"
       },
       {
         "name": "SKSApps OPL Theme Guide Archive (Outdated)",
-        "url": "https://web.archive.org/web/20170412171607/http://opl.sksapps.com/index.php?opl=theme.html"
+        "url": "https://web.archive.org/web/20170412171607/http://opl.sksapps.com/index.php?opl=theme.html",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "The Cover Project (Art)",
-        "url": "https://www.thecoverproject.net/view.php?cat_id=6"
+        "url": "https://www.thecoverproject.net/view.php?cat_id=6",
+        "favicon_url": "https://www.thecoverproject.net/favicon.ico"
       },
       {
         "name": "Video Game Box Art Box Design Showcase",
-        "url": "https://vgboxart.com/browse-covers/PS2/"
+        "url": "https://vgboxart.com/browse-covers/PS2/",
+        "favicon_url": "https://vgboxart.com/favicon.ico"
       },
       {
         "name": "WAV to ADP Converter for OPL Theme Sounds/BGM",
-        "url": "https://www.psx-place.com/threads/wav-to-adp-converter-for-opl.21568/"
+        "url": "https://www.psx-place.com/threads/wav-to-adp-converter-for-opl.21568/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Widescreen Game Cheats by sync-on-luma",
-        "url": "https://github.com/sync-on-luma/PS2-widescreen-cheats"
+        "url": "https://github.com/sync-on-luma/PS2-widescreen-cheats",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Widescreen Game Patches",
-        "url": "https://forums.pcsx2.net/Thread-PCSX2-Widescreen-Game-Patches?pid=271674#pid271674"
+        "url": "https://forums.pcsx2.net/Thread-PCSX2-Widescreen-Game-Patches?pid=271674#pid271674",
+        "favicon_url": "https://forums.pcsx2.net/favicon.ico"
       }
     ]
   },
@@ -1103,175 +1370,218 @@
     "links": [
       {
         "name": "8bitdo.com's PS2 Accessories",
-        "url": "https://www.8bitdo.com/#Products"
+        "url": "https://www.8bitdo.com/#Products",
+        "favicon_url": "https://www.8bitdo.com/favicon.ico"
       },
       {
         "name": "8bitmods.com's PS2 Accessories",
-        "url": "https://8bitmods.com/shop-by-console/sony/playstation-2/"
+        "url": "https://8bitmods.com/shop-by-console/sony/playstation-2/",
+        "favicon_url": "https://8bitmods.com/favicon.ico"
       },
       {
         "name": "AliExpress: Additional Hardware",
-        "url": "https://www.aliexpress.us/item/3256805974551961.html"
+        "url": "https://www.aliexpress.us/item/3256805974551961.html",
+        "favicon_url": "https://www.aliexpress.us/favicon.ico"
       },
       {
         "name": "AliExpress: Item EusgZGC",
-        "url": "https://a.aliexpress.com/_EusgZGC"
+        "url": "https://a.aliexpress.com/_EusgZGC",
+        "favicon_url": "https://a.aliexpress.com/favicon.ico"
       },
       {
         "name": "Arthrimus PS2 Mods and Parts - including Slim HDD Mod Iflash2PS2",
-        "url": "https://arthrimus.com/"
+        "url": "https://arthrimus.com/",
+        "favicon_url": "https://arthrimus.com/favicon.ico"
       },
       {
         "name": "BitFunx Official 2.0 IDE to SATA Chip Swap for Official PS2 Network Adapters",
-        "url": "https://www.aliexpress.com/item/32809586287.html"
+        "url": "https://www.aliexpress.com/item/32809586287.html",
+        "favicon_url": "https://www.aliexpress.com/favicon.ico"
       },
       {
         "name": "BitFunx Official Gamestar SATA Network (No Network) Adapter - Not recommended/Mixed Reviews",
-        "url": "https://www.aliexpress.com/item/2251832549771984.html"
+        "url": "https://www.aliexpress.com/item/2251832549771984.html",
+        "favicon_url": "https://www.aliexpress.com/favicon.ico"
       },
       {
         "name": "BitFunx Official MX4SIO",
-        "url": "https://www.aliexpress.com/item/3256804671298047.html"
+        "url": "https://www.aliexpress.com/item/3256804671298047.html",
+        "favicon_url": "https://www.aliexpress.com/favicon.ico"
       },
       {
         "name": "Bitfunx AliExpress Store",
-        "url": "https://bitfunx.aliexpress.com/store/1100940502/pages/all-items.html"
+        "url": "https://bitfunx.aliexpress.com/store/1100940502/pages/all-items.html",
+        "favicon_url": "https://bitfunx.aliexpress.com/favicon.ico"
       },
       {
         "name": "Bitfunx sd2psx (MemCard Gen2) mirror",
-        "url": "https://www.aliexpress.us/item/3256807978598346.html"
+        "url": "https://www.aliexpress.us/item/3256807978598346.html",
+        "favicon_url": "https://www.aliexpress.us/favicon.ico"
       },
       {
         "name": "Bitfunx sd2psx Release(MemCard Gen2)",
-        "url": "https://www.aliexpress.us/item/3256807978476851.html"
+        "url": "https://www.aliexpress.us/item/3256807978476851.html",
+        "favicon_url": "https://www.aliexpress.us/favicon.ico"
       },
       {
         "name": "Blue Retro Core PADEMU Device",
-        "url": "https://www.blue-retro.com/"
+        "url": "https://www.blue-retro.com/",
+        "favicon_url": "https://www.blue-retro.com/favicon.ico"
       },
       {
         "name": "Brook's Wingman PS2 Controller Adapter",
-        "url": "https://www.brookaccessory.com/products/wingmanps2/index.html"
+        "url": "https://www.brookaccessory.com/products/wingmanps2/index.html",
+        "favicon_url": "https://www.brookaccessory.com/favicon.ico"
       },
       {
         "name": "Crystal Chip R34 v3",
-        "url": "https://github.com/saildot4k/Crystal-Chip-R34-v3"
+        "url": "https://github.com/saildot4k/Crystal-Chip-R34-v3",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "ElectronAnalog HDMI Mod",
-        "url": "https://electron-shepherd.com/collections/all/products/electronanalog"
+        "url": "https://electron-shepherd.com/collections/all/products/electronanalog",
+        "favicon_url": "https://electron-shepherd.com/favicon.ico"
       },
       {
         "name": "ElectronPulse HDMI Plug and Play",
-        "url": "https://electron-shepherd.com/products/electronpulse"
+        "url": "https://electron-shepherd.com/products/electronpulse",
+        "favicon_url": "https://electron-shepherd.com/favicon.ico"
       },
       {
         "name": "GitHub: PSxMemCardGen2 by GameBitFunx",
-        "url": "https://github.com/gamebitfunx/PSxMemCardGen2"
+        "url": "https://github.com/gamebitfunx/PSxMemCardGen2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "GitHub: PicoDrive by Irixxxx",
-        "url": "https://github.com/irixxxx/picodrive"
+        "url": "https://github.com/irixxxx/picodrive",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "GitHub: PicoMemcard by Dangiu",
-        "url": "https://github.com/dangiu/PicoMemcard"
+        "url": "https://github.com/dangiu/PicoMemcard",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Gusse Retro Shop's Mods and Parts - including Methylene",
-        "url": "https://gusse.in/"
+        "url": "https://gusse.in/",
+        "favicon_url": "https://gusse.in/favicon.ico"
       },
       {
         "name": "Helder's Gametech/MC2SIO",
-        "url": "https://heldergametech.com/"
+        "url": "https://heldergametech.com/",
+        "favicon_url": "https://heldergametech.com/favicon.ico"
       },
       {
         "name": "Kaico Gamestar SATA Network (No Network) HDD Adapter - Not recommended/Mixed Reviews",
-        "url": "https://a.co/d/6Sr3xDZ"
+        "url": "https://a.co/d/6Sr3xDZ",
+        "favicon_url": "https://a.co/favicon.ico"
       },
       {
         "name": "Kaico PS1/PS2 AV to HDMI Cable for all PS1 & PS2 Models - Swaps between RGB/Component",
-        "url": "https://a.co/d/dKIL69c"
+        "url": "https://a.co/d/dKIL69c",
+        "favicon_url": "https://a.co/favicon.ico"
       },
       {
         "name": "Kaico SATA Network Adapter Upgrade",
-        "url": "https://a.co/d/7itdPZ3"
+        "url": "https://a.co/d/7itdPZ3",
+        "favicon_url": "https://a.co/favicon.ico"
       },
       {
         "name": "MOD Chip Files of Various Make",
-        "url": "https://github.com/m4x10187/ps2-modchip-files"
+        "url": "https://github.com/m4x10187/ps2-modchip-files",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "MOD Chip Matrix Team Actel APA075 based modchips flash dump. (Not FPGA firmware!)",
-        "url": "https://github.com/78edu/ps2-matrix-infinity-modchip-dump"
+        "url": "https://github.com/78edu/ps2-matrix-infinity-modchip-dump",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Megidish Retro Shop",
-        "url": "https://megidish.net/"
+        "url": "https://megidish.net/",
+        "favicon_url": "https://megidish.net/favicon.ico"
       },
       {
         "name": "MemCardPro2 VMC Device",
-        "url": "https://8bitmods.com/memcard-pro2-for-ps2-and-ps1-smoke-black/#tab-description"
+        "url": "https://8bitmods.com/memcard-pro2-for-ps2-and-ps1-smoke-black/#tab-description",
+        "favicon_url": "https://8bitmods.com/favicon.ico"
       },
       {
         "name": "MG2BOX (MX4SIO)",
-        "url": "https://www.aliexpress.us/item/3256805234828516.html"
+        "url": "https://www.aliexpress.us/item/3256805234828516.html",
+        "favicon_url": "https://www.aliexpress.us/favicon.ico"
       },
       {
         "name": "Official Blue Retro by darthcloud",
-        "url": "https://darthcloud.itch.io/blueretro"
+        "url": "https://darthcloud.itch.io/blueretro",
+        "favicon_url": "https://darthcloud.itch.io/favicon.ico"
       },
       {
         "name": "Official Sony Network Adapters (Recommended via Ebay or other resellers)",
-        "url": "https://www.psdevwiki.com/ps2/Network_Adaptor"
+        "url": "https://www.psdevwiki.com/ps2/Network_Adaptor",
+        "favicon_url": "https://www.psdevwiki.com/favicon.ico"
       },
       {
         "name": "PS2 Chip Modifications Wiki",
-        "url": "https://www.willsconsolemodifications.co.uk/ps2-wiki/chips.php"
+        "url": "https://www.willsconsolemodifications.co.uk/ps2-wiki/chips.php",
+        "favicon_url": "https://www.willsconsolemodifications.co.uk/favicon.ico"
       },
       {
         "name": "PS2 Controller Remapper",
-        "url": "https://www.psx-place.com/resources/ps2-controller-remapper-by-pelvicthrustman.692/"
+        "url": "https://www.psx-place.com/resources/ps2-controller-remapper-by-pelvicthrustman.692/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PS2 Easy HDD",
-        "url": "https://github.com/jeffqchen/PS2EasyHDD"
+        "url": "https://github.com/jeffqchen/PS2EasyHDD",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 Laser Fix",
-        "url": "https://github.com/nostalgic-indulgences/PS2_Laserfix"
+        "url": "https://github.com/nostalgic-indulgences/PS2_Laserfix",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "RETRO Gem HDMI Mods",
-        "url": "https://www.pixelfx.co/product-page/retro-gem-universal-hdmi-upscaler-kit"
+        "url": "https://www.pixelfx.co/product-page/retro-gem-universal-hdmi-upscaler-kit",
+        "favicon_url": "https://www.pixelfx.co/favicon.ico"
       },
       {
         "name": "RETROTink Video Solutions",
-        "url": "https://www.retrotink.com/"
+        "url": "https://www.retrotink.com/",
+        "favicon_url": "https://www.retrotink.com/favicon.ico"
       },
       {
         "name": "RGEEK Gamestar SATA Network (No Network) HDD Adapter - Not recommended/Mixed Reviews",
-        "url": "https://a.co/d/2LvnbWI"
+        "url": "https://a.co/d/2LvnbWI",
+        "favicon_url": "https://a.co/favicon.ico"
       },
       {
         "name": "SD2PSX Custom GameID Detection Firmware by bbsan22",
-        "url": "https://github.com/bbsan2k/sd2psx_firmware"
+        "url": "https://github.com/bbsan2k/sd2psx_firmware",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "SD2PSX Official github",
-        "url": "https://github.com/sd2psx"
+        "url": "https://github.com/sd2psx",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "SD2PSX VMC Device",
-        "url": "https://sd2psx.net/"
+        "url": "https://sd2psx.net/",
+        "favicon_url": "https://sd2psx.net/favicon.ico"
       },
       {
         "name": "USB Optical Wireless Bluetooth Transmitter 2 in 1 Audio Transmitter Adapter Low Lantency For TV PC USB Wireless Audio Adapter",
-        "url": "https://www.aliexpress.us/item/3256806809890714.html"
+        "url": "https://www.aliexpress.us/item/3256806809890714.html",
+        "favicon_url": "https://www.aliexpress.us/favicon.ico"
       },
       {
         "name": "pcp.tech's SD2PSX Ebay Listing - Verified SD2PSX Reseller on Ebay",
-        "url": "https://www.ebay.com/itm/314357590044"
+        "url": "https://www.ebay.com/itm/314357590044",
+        "favicon_url": "https://www.ebay.com/favicon.ico"
       }
     ]
   },
@@ -1281,91 +1591,113 @@
     "links": [
       {
         "name": "DNAS-net Patcher",
-        "url": "https://www.psx-place.com/threads/dnas-net-patcher.22813/"
+        "url": "https://www.psx-place.com/threads/dnas-net-patcher.22813/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Official OBSRV Server Discord Server",
-        "url": "https://discord.gg/r9v3DKG"
+        "url": "https://discord.gg/r9v3DKG",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Open PS2 Loader NAS SMB Troubleshooting Tips",
-        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=12689#p49670"
+        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=12689#p49670",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader NAS SMB Troubleshooting Tips (Archive)",
-        "url": "https://web.archive.org/web/20241208123804/https://www.ps2-home.com/forum/viewtopic.php?t=12689#p49670"
+        "url": "https://web.archive.org/web/20241208123804/https://www.ps2-home.com/forum/viewtopic.php?t=12689#p49670",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Guide",
-        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=3692"
+        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=3692",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Guide (Archive)",
-        "url": "https://web.archive.org/web/20241121150504/https://www.ps2-home.com/forum/viewtopic.php?t=3692"
+        "url": "https://web.archive.org/web/20241121150504/https://www.ps2-home.com/forum/viewtopic.php?t=3692",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Guide for Linux Systems",
-        "url": "https://www.psx-place.com/threads/opl-smb-linux-configuration-guide.20638/"
+        "url": "https://www.psx-place.com/threads/opl-smb-linux-configuration-guide.20638/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Guide for Windows",
-        "url": "https://www.psx-place.com/threads/opl-network-connection-in-windows-10.40899/"
+        "url": "https://www.psx-place.com/threads/opl-network-connection-in-windows-10.40899/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Troubleshooting for Windows",
-        "url": "https://ps2-home.com/forum/viewtopic.php?t=4926"
+        "url": "https://ps2-home.com/forum/viewtopic.php?t=4926",
+        "favicon_url": "https://ps2-home.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader SMB Troubleshooting for Windows (Archive)",
-        "url": "https://web.archive.org/web/20241121143157/https://ps2-home.com/forum/viewtopic.php?t=4926"
+        "url": "https://web.archive.org/web/20241121143157/https://ps2-home.com/forum/viewtopic.php?t=4926",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Open PS2 Loader UDPBD Linux Setup Guide by OpenAI",
-        "url": "https://chatgpt.com/share/674216e4-825c-8001-8b0b-14b03d8f8dab"
+        "url": "https://chatgpt.com/share/674216e4-825c-8001-8b0b-14b03d8f8dab",
+        "favicon_url": "https://chatgpt.com/favicon.ico"
       },
       {
         "name": "OpenSpy's PS2 Online Servers",
-        "url": "https://ps2online.com/"
+        "url": "https://ps2online.com/",
+        "favicon_url": "https://ps2online.com/favicon.ico"
       },
       {
         "name": "OpenSpy's PS2 Online's Discord Server",
-        "url": "https://discord.com/invite/zE79nWT"
+        "url": "https://discord.com/invite/zE79nWT",
+        "favicon_url": "https://discord.com/favicon.ico"
       },
       {
         "name": "PS Rewired Discord Server",
-        "url": "https://discord.gg/VfeuF6ZWVb"
+        "url": "https://discord.gg/VfeuF6ZWVb",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PS Rewired emulated Online Servers",
-        "url": "https://psrewired.com/"
+        "url": "https://psrewired.com/",
+        "favicon_url": "https://psrewired.com/favicon.ico"
       },
       {
         "name": "PS2 Online Gaming",
-        "url": "https://ps2onlinegaming.com/"
+        "url": "https://ps2onlinegaming.com/",
+        "favicon_url": "https://ps2onlinegaming.com/favicon.ico"
       },
       {
         "name": "PS2 Online Gaming's Discord Server",
-        "url": "https://discord.gg/N2akedR"
+        "url": "https://discord.gg/N2akedR",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PSORG (PS Online Returnal Games) Discord Server",
-        "url": "https://discord.gg/DQbrEb44qr"
+        "url": "https://discord.gg/DQbrEb44qr",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "PSX Capture (PS2 - PS5) Online Discord Server",
-        "url": "https://discord.gg/FYmVq6zmgx"
+        "url": "https://discord.gg/FYmVq6zmgx",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Romstation.fr Multiplayer",
-        "url": "https://www.romstation.fr/multiplayer/"
+        "url": "https://www.romstation.fr/multiplayer/",
+        "favicon_url": "https://www.romstation.fr/favicon.ico"
       },
       {
         "name": "Team XLink (Official) Discord Server",
-        "url": "https://discord.gg/vdf7Q3v"
+        "url": "https://discord.gg/vdf7Q3v",
+        "favicon_url": "https://discord.gg/favicon.ico"
       },
       {
         "name": "Team XLink Global Network Gaming",
-        "url": "https://www.teamxlink.co.uk/"
+        "url": "https://www.teamxlink.co.uk/",
+        "favicon_url": "https://www.teamxlink.co.uk/favicon.ico"
       }
     ]
   },
@@ -1375,267 +1707,333 @@
     "links": [
       {
         "name": "AEP Emulation Page",
-        "url": "http://www.aep-emu.de/"
+        "url": "http://www.aep-emu.de/",
+        "favicon_url": "http://www.aep-emu.de/favicon.ico"
       },
       {
         "name": "Additional Projects by El_isra",
-        "url": "https://israpps.github.io/projects/"
+        "url": "https://israpps.github.io/projects/",
+        "favicon_url": "https://israpps.github.io/favicon.ico"
       },
       {
         "name": "AssemblerGames Forum Archive",
-        "url": "https://web.archive.org/web/20191206184256/https://assemblergames.com/"
+        "url": "https://web.archive.org/web/20191206184256/https://assemblergames.com/",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "CD Media World",
-        "url": "https://cdmediaworld.com/hardware/cdrom/cd.shtml"
+        "url": "https://cdmediaworld.com/hardware/cdrom/cd.shtml",
+        "favicon_url": "https://cdmediaworld.com/favicon.ico"
       },
       {
         "name": "Console Mods PS2 Model Differences",
-        "url": "https://consolemods.org/wiki/PS2:Model_Differences"
+        "url": "https://consolemods.org/wiki/PS2:Model_Differences",
+        "favicon_url": "https://consolemods.org/favicon.ico"
       },
       {
         "name": "Console5's PS2 Wiki",
-        "url": "https://wiki.console5.com/wiki/PlayStation_2"
+        "url": "https://wiki.console5.com/wiki/PlayStation_2",
+        "favicon_url": "https://wiki.console5.com/favicon.ico"
       },
       {
         "name": "DESR Dev github.io",
-        "url": "https://desrdev.github.io/"
+        "url": "https://desrdev.github.io/",
+        "favicon_url": "https://desrdev.github.io/favicon.ico"
       },
       {
         "name": "Emu-France",
-        "url": "http://emu-france.com/"
+        "url": "http://emu-france.com/",
+        "favicon_url": "http://emu-france.com/favicon.ico"
       },
       {
         "name": "EmuCR",
-        "url": "http://www.emucr.com"
+        "url": "http://www.emucr.com",
+        "favicon_url": "http://www.emucr.com/favicon.ico"
       },
       {
         "name": "Emudreams",
-        "url": "http://www.emudreams.pl/"
+        "url": "http://www.emudreams.pl/",
+        "favicon_url": "http://www.emudreams.pl/favicon.ico"
       },
       {
         "name": "Emuparadise.me",
-        "url": "https://www.emuparadise.me/"
+        "url": "https://www.emuparadise.me/",
+        "favicon_url": "https://www.emuparadise.me/favicon.ico"
       },
       {
         "name": "Fobes.dev by Fobes",
-        "url": "https://fobes.dev/"
+        "url": "https://fobes.dev/",
+        "favicon_url": "https://fobes.dev/favicon.ico"
       },
       {
         "name": "Game Rave Perfect Guides",
-        "url": "http://www.game-rave.com"
+        "url": "http://www.game-rave.com",
+        "favicon_url": "http://www.game-rave.com/favicon.ico"
       },
       {
         "name": "Gamefaqs PS2 Guides, Cheats, Saves and More",
-        "url": "https://gamefaqs.gamespot.com/ps2"
+        "url": "https://gamefaqs.gamespot.com/ps2",
+        "favicon_url": "https://gamefaqs.gamespot.com/favicon.ico"
       },
       {
         "name": "Gamekult",
-        "url": "http://www.gamekult.com/"
+        "url": "http://www.gamekult.com/",
+        "favicon_url": "http://www.gamekult.com/favicon.ico"
       },
       {
         "name": "Gaming Alexandria",
-        "url": "https://www.gamingalexandria.com/wp/"
+        "url": "https://www.gamingalexandria.com/wp/",
+        "favicon_url": "https://www.gamingalexandria.com/favicon.ico"
       },
       {
         "name": "Haldrie's SKSApps Backup",
-        "url": "https://sksapps.haldrie.com/"
+        "url": "https://sksapps.haldrie.com/",
+        "favicon_url": "https://sksapps.haldrie.com/favicon.ico"
       },
       {
         "name": "Hardlevel.com.br",
-        "url": "https://hardlevel.com.br/"
+        "url": "https://hardlevel.com.br/",
+        "favicon_url": "https://hardlevel.com.br/favicon.ico"
       },
       {
         "name": "HDD Compatibility Chart (Incomplete)",
-        "url": "https://ps2drives.x-pec.com/"
+        "url": "https://ps2drives.x-pec.com/",
+        "favicon_url": "https://ps2drives.x-pec.com/favicon.ico"
       },
       {
         "name": "HDLoader.com Archive",
-        "url": "https://web.archive.org/web/20110106074036/http://hdloader.net/"
+        "url": "https://web.archive.org/web/20110106074036/http://hdloader.net/",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "ifixit's PS2 Repair Guide and Documentation",
-        "url": "https://www.ifixit.com/Device/PlayStation_2"
+        "url": "https://www.ifixit.com/Device/PlayStation_2",
+        "favicon_url": "https://www.ifixit.com/favicon.ico"
       },
       {
         "name": "Link World",
-        "url": "https://lnkworld.com/playstation.shtml"
+        "url": "https://lnkworld.com/playstation.shtml",
+        "favicon_url": "https://lnkworld.com/favicon.ico"
       },
       {
         "name": "MCP2 Manual",
-        "url": "https://qrco.de/bdiiDa"
+        "url": "https://qrco.de/bdiiDa",
+        "favicon_url": "https://qrco.de/favicon.ico"
       },
       {
         "name": "Memory Card Groups Documentation by sync-on-luma",
-        "url": "https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin/wiki/Memory-Card-Groups"
+        "url": "https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin/wiki/Memory-Card-Groups",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "MOD Chip Disable Procedures and Tips",
-        "url": "https://www.psx-place.com/threads/modchip-disable-procedure.31585/"
+        "url": "https://www.psx-place.com/threads/modchip-disable-procedure.31585/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Mobygames",
-        "url": "http://www.mobygames.com/home"
+        "url": "http://www.mobygames.com/home",
+        "favicon_url": "http://www.mobygames.com/favicon.ico"
       },
       {
         "name": "Mongoose http Server on PS2 Example",
-        "url": "https://github.com/F0bes/ps2_http"
+        "url": "https://github.com/F0bes/ps2_http",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "MundoWiiHack's Wordpress - Check PS2 Sections",
-        "url": "https://mundowiihack.wordpress.com/"
+        "url": "https://mundowiihack.wordpress.com/",
+        "favicon_url": "https://mundowiihack.wordpress.com/favicon.ico"
       },
       {
         "name": "Neutrino Launcher Wiki Compatibility List sync-on-luma",
-        "url": "https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin/wiki/Compatibility-List"
+        "url": "https://github.com/sync-on-luma/xebplus-neutrino-loader-plugin/wiki/Compatibility-List",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Obscure Gamers Archive",
-        "url": "https://archive.obscuregamers.com/"
+        "url": "https://archive.obscuregamers.com/",
+        "favicon_url": "https://archive.obscuregamers.com/favicon.ico"
       },
       {
         "name": "Open PS2 Loader Official Page",
-        "url": "https://www.ps2homebrew.org/Open-PS2-Loader/"
+        "url": "https://www.ps2homebrew.org/Open-PS2-Loader/",
+        "favicon_url": "https://www.ps2homebrew.org/favicon.ico"
       },
       {
         "name": "Open PS2 Loader User Guide for 0.9.3",
-        "url": "https://www.ps2homebrew.org/Open-PS2-Loader-User-Guide/"
+        "url": "https://www.ps2homebrew.org/Open-PS2-Loader-User-Guide/",
+        "favicon_url": "https://www.ps2homebrew.org/favicon.ico"
       },
       {
         "name": "Planetemu",
-        "url": "http://planetemu.net/"
+        "url": "http://planetemu.net/",
+        "favicon_url": "http://planetemu.net/favicon.ico"
       },
       {
         "name": "PS2 Bios Archive",
-        "url": "https://archive.org/details/the-ultimate-ps2-bios-collection"
+        "url": "https://archive.org/details/the-ultimate-ps2-bios-collection",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PS2 Developer Wiki",
-        "url": "https://www.psdevwiki.com/ps2/"
+        "url": "https://www.psdevwiki.com/ps2/",
+        "favicon_url": "https://www.psdevwiki.com/favicon.ico"
       },
       {
         "name": "PS2 Documentation mirror github",
-        "url": "https://github.com/ps2dev-mirror/doc"
+        "url": "https://github.com/ps2dev-mirror/doc",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 FPU Testing Page by Fobes",
-        "url": "https://ps2.fobes.dev/"
+        "url": "https://ps2.fobes.dev/",
+        "favicon_url": "https://ps2.fobes.dev/favicon.ico"
       },
       {
         "name": "PS2 Homebrew.org Site",
-        "url": "https://www.ps2homebrew.org/"
+        "url": "https://www.ps2homebrew.org/",
+        "favicon_url": "https://www.ps2homebrew.org/favicon.ico"
       },
       {
         "name": "PS2 Icon Format v0.5 Documentation",
-        "url": "http://www.csclub.uwaterloo.ca:11068/mymc/ps2icon-0.5.pdf"
+        "url": "http://www.csclub.uwaterloo.ca:11068/mymc/ps2icon-0.5.pdf",
+        "favicon_url": "http://www.csclub.uwaterloo.ca:11068/favicon.ico"
       },
       {
         "name": "PS2 Icons Open Database",
-        "url": "https://ps2iodb.com"
+        "url": "https://ps2iodb.com",
+        "favicon_url": "https://ps2iodb.com/favicon.ico"
       },
       {
         "name": "PS2 Memory Card File System Documentation",
-        "url": "http://www.csclub.uwaterloo.ca:11068/mymc/ps2mcfs.html"
+        "url": "http://www.csclub.uwaterloo.ca:11068/mymc/ps2mcfs.html",
+        "favicon_url": "http://www.csclub.uwaterloo.ca:11068/favicon.ico"
       },
       {
         "name": "PS2 Programming Documents github",
-        "url": "https://github.com/DarrenRainey/PS2-Programming-Docs"
+        "url": "https://github.com/DarrenRainey/PS2-Programming-Docs",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS2 ROM Information PDF",
-        "url": "https://app.filen.io/#/d/c936c3aa-8920-495d-a515-b34b57ac662f#BLTymcMaDnCYQDH7kmLMjRKijWUst6mQ)"
+        "url": "https://app.filen.io/#/d/c936c3aa-8920-495d-a515-b34b57ac662f#BLTymcMaDnCYQDH7kmLMjRKijWUst6mQ)",
+        "favicon_url": "https://app.filen.io/favicon.ico"
       },
       {
         "name": "PS2 Save Tools Homepage",
-        "url": "https://www.ps2savetools.com/"
+        "url": "https://www.ps2savetools.com/",
+        "favicon_url": "https://www.ps2savetools.com/favicon.ico"
       },
       {
         "name": "PS2 Vault",
-        "url": "https://howlingwolfhwc.github.io/ps2vault/"
+        "url": "https://howlingwolfhwc.github.io/ps2vault/",
+        "favicon_url": "https://howlingwolfhwc.github.io/favicon.ico"
       },
       {
         "name": "PS2 Wiki",
-        "url": "https://ps2wiki.github.io/"
+        "url": "https://ps2wiki.github.io/",
+        "favicon_url": "https://ps2wiki.github.io/favicon.ico"
       },
       {
         "name": "PS2-Home Archive",
-        "url": "https://web.archive.org/web/20240914160929/https://www.ps2-home.com/forum/app.php/portal?sid=993deede5f113a38f2dc173d002446c1"
+        "url": "https://web.archive.org/web/20240914160929/https://www.ps2-home.com/forum/app.php/portal?sid=993deede5f113a38f2dc173d002446c1",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "PS2Wiki Team github",
-        "url": "https://github.com/ps2wiki"
+        "url": "https://github.com/ps2wiki",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "PS3 Memory Card Adapter Wiki",
-        "url": "https://www.psdevwiki.com/ps3/Card_Adapter"
+        "url": "https://www.psdevwiki.com/ps3/Card_Adapter",
+        "favicon_url": "https://www.psdevwiki.com/favicon.ico"
       },
       {
         "name": "PSX Data Center",
-        "url": "https://psxdatacenter.com/psx2/sitenews2.html"
+        "url": "https://psxdatacenter.com/psx2/sitenews2.html",
+        "favicon_url": "https://psxdatacenter.com/favicon.ico"
       },
       {
         "name": "PSX-Place's PS2 Resources Directory",
-        "url": "https://www.psx-place.com/resources/categories/playstation-2-ps2.7/"
+        "url": "https://www.psx-place.com/resources/categories/playstation-2-ps2.7/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "Redump.org's PS2 Verification Database",
-        "url": "http://redump.org/discs/system/ps2/"
+        "url": "http://redump.org/discs/system/ps2/",
+        "favicon_url": "http://redump.org/favicon.ico"
       },
       {
         "name": "Restorative Land Geocities (Old)",
-        "url": "https://geocities.restorativland.org/SiliconValley/Station/8269/"
+        "url": "https://geocities.restorativland.org/SiliconValley/Station/8269/",
+        "favicon_url": "https://geocities.restorativland.org/favicon.ico"
       },
       {
         "name": "RETRORGB's PS2 Page",
-        "url": "https://www.retrorgb.com/playstation2.html"
+        "url": "https://www.retrorgb.com/playstation2.html",
+        "favicon_url": "https://www.retrorgb.com/favicon.ico"
       },
       {
         "name": "RFGeneration",
-        "url": "http://www.rfgeneration.com"
+        "url": "http://www.rfgeneration.com",
+        "favicon_url": "http://www.rfgeneration.com/favicon.ico"
       },
       {
         "name": "Savegame Icon Library and Documentation github",
-        "url": "https://github.com/ticky/ps2icon"
+        "url": "https://github.com/ticky/ps2icon",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "ShaolinAssassin's POPSTARTER Wiki",
-        "url": "https://bitbucket.org/ShaolinAssassin/popstarter-documentation-stuff/wiki/browse/"
+        "url": "https://bitbucket.org/ShaolinAssassin/popstarter-documentation-stuff/wiki/browse/",
+        "favicon_url": "https://bitbucket.org/favicon.ico"
       },
       {
-        "name": "THE INSIDERS ’ GUIDE TO MICROPROCESSOR: HARDWARE REPORT: Sony’s Emotionally Charged Chip (VOLUME 13, NUMBER 5 APRIL 19, 1999)",
-        "url": "https://websrv.cecs.uci.edu/~papers/mpr/MPR/19990419/130501.pdf"
+        "name": "THE INSIDERS \u2019 GUIDE TO MICROPROCESSOR: HARDWARE REPORT: Sony\u2019s Emotionally Charged Chip (VOLUME 13, NUMBER 5 APRIL 19, 1999)",
+        "url": "https://websrv.cecs.uci.edu/~papers/mpr/MPR/19990419/130501.pdf",
+        "favicon_url": "https://websrv.cecs.uci.edu/favicon.ico"
       },
       {
         "name": "The Cutting Room Floor Game Content Wiki",
-        "url": "https://tcrf.net/Category:PlayStation_2_games"
+        "url": "https://tcrf.net/Category:PlayStation_2_games",
+        "favicon_url": "https://tcrf.net/favicon.ico"
       },
       {
         "name": "uLaunchELF Wiki",
-        "url": "http://ps2ulaunchelf.pbworks.com/w/page/19520134/FrontPage"
+        "url": "http://ps2ulaunchelf.pbworks.com/w/page/19520134/FrontPage",
+        "favicon_url": "http://ps2ulaunchelf.pbworks.com/favicon.ico"
       },
       {
         "name": "Usagiru's Blog",
-        "url": "https://usagiru.blogspot.com/"
+        "url": "https://usagiru.blogspot.com/",
+        "favicon_url": "https://usagiru.blogspot.com/favicon.ico"
       },
       {
         "name": "Video Game Museum",
-        "url": "https://www.vgmuseum.com/ps2.htm"
+        "url": "https://www.vgmuseum.com/ps2.htm",
+        "favicon_url": "https://www.vgmuseum.com/favicon.ico"
       },
       {
         "name": "Wayback Machine's FreeMCBoot.info Backup",
-        "url": "https://web.archive.org/web/20130529175034/http://freemcboot.info/index.html"
+        "url": "https://web.archive.org/web/20130529175034/http://freemcboot.info/index.html",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Wayback Machine's OpenPS2Loader.info Backup",
-        "url": "https://web.archive.org/web/20130601035035/http://openps2loader.info:80/"
+        "url": "https://web.archive.org/web/20130601035035/http://openps2loader.info:80/",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "Wayback Machine's SKSApps Backup",
-        "url": "https://web.archive.org/web/20160818064541/http://sksapps.com:80/"
+        "url": "https://web.archive.org/web/20160818064541/http://sksapps.com:80/",
+        "favicon_url": "https://web.archive.org/favicon.ico"
       },
       {
         "name": "ps2tek's PS2 Comprehensive Hardware Reference",
-        "url": "https://psi-rockin.github.io/ps2tek/"
+        "url": "https://psi-rockin.github.io/ps2tek/",
+        "favicon_url": "https://psi-rockin.github.io/favicon.ico"
       }
     ]
   },
@@ -1645,123 +2043,153 @@
     "links": [
       {
         "name": "Bomberman Online",
-        "url": "https://archive.org/details/bomberman-online-10300-0"
+        "url": "https://archive.org/details/bomberman-online-10300-0",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "CosmicScale's PSBBN Definitive English Patch",
-        "url": "https://github.com/CosmicScale/PSBBN-Definitive-English-Patch/"
+        "url": "https://github.com/CosmicScale/PSBBN-Definitive-English-Patch/",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Download sony_ps2linux_install_image.tgz",
-        "url": "https://sourceforge.net/projects/kernelloader/files/Sony%20Linux%20Toolkit/"
+        "url": "https://sourceforge.net/projects/kernelloader/files/Sony%20Linux%20Toolkit/",
+        "favicon_url": "https://sourceforge.net/favicon.ico"
       },
       {
         "name": "Guide to install Linux on APA and upgrade to the 2.2.21 kernel",
-        "url": "http://ps2-linux.tensioncore.com/download/apa/apa_xrhino_2.2.21-pre1-xr7.html"
+        "url": "http://ps2-linux.tensioncore.com/download/apa/apa_xrhino_2.2.21-pre1-xr7.html",
+        "favicon_url": "http://ps2-linux.tensioncore.com/favicon.ico"
       },
       {
         "name": "Instructions for setting up dual-boot with Akmem",
-        "url": "https://hp.vector.co.jp/authors/VA008536/ps2linux/akmem.html"
+        "url": "https://hp.vector.co.jp/authors/VA008536/ps2linux/akmem.html",
+        "favicon_url": "https://hp.vector.co.jp/favicon.ico"
       },
       {
         "name": "Kernelloader 3.0 for installing Linux without the Official Sony Linux RTE disc",
-        "url": "https://sourceforge.net/projects/kernelloader/files/Kernelloader/Kernelloader%203.0/"
+        "url": "https://sourceforge.net/projects/kernelloader/files/Kernelloader/Kernelloader%203.0/",
+        "favicon_url": "https://sourceforge.net/favicon.ico"
       },
       {
         "name": "Linux 2.2.1 from Sony's Linux Toolkit",
-        "url": "https://github.com/jur/linux-2.2.1-ps2"
+        "url": "https://github.com/jur/linux-2.2.1-ps2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Linux 2.4.17 Patched for PS2",
-        "url": "https://github.com/rickgaiser/linux-2.4.17-ps2"
+        "url": "https://github.com/rickgaiser/linux-2.4.17-ps2",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Linux 2.6.35.4 mipsel PS2 Mod",
-        "url": "https://github.com/anikkcah/PS2Linux"
+        "url": "https://github.com/anikkcah/PS2Linux",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Linux Kernel 2.2.1 for PS2",
-        "url": "https://github.com/azagramac/ps2-linux"
+        "url": "https://github.com/azagramac/ps2-linux",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Linux Kernel for PS2",
-        "url": "https://github.com/frno7/linux"
+        "url": "https://github.com/frno7/linux",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "Linux kernel source: linux-2.2.21-pre1-xr7.tar.gz",
-        "url": "https://archive.org/download/linux-playstation2-sources/linux-2.2.21-pre1-xr7.tar.gz"
+        "url": "https://archive.org/download/linux-playstation2-sources/linux-2.2.21-pre1-xr7.tar.gz",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "Linux Sources for PlayStation 2",
-        "url": "https://archive.org/details/linux-playstation2-sources"
+        "url": "https://archive.org/details/linux-playstation2-sources",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PS2 HDD Images and Dumps",
-        "url": "https://archive.org/details/ps2-hdd-imgs-dumps"
+        "url": "https://archive.org/details/ps2-hdd-imgs-dumps",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PS2 Linux unOfficial Site",
-        "url": "https://ps2linux.no-ip.info/home/"
+        "url": "https://ps2linux.no-ip.info/home/",
+        "favicon_url": "https://ps2linux.no-ip.info/favicon.ico"
       },
       {
         "name": "PSBBN Archive",
-        "url": "https://archive.org/details/psbbn"
+        "url": "https://archive.org/details/psbbn",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN Definitive English Patch by CosmicScale",
-        "url": "https://archive.org/details/playstation-broadband-navigator-psbbn-definitive-english-patch-v1.0"
+        "url": "https://archive.org/details/playstation-broadband-navigator-psbbn-definitive-english-patch-v1.0",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN Definitive English Patch v2",
-        "url": "https://archive.org/details/psbbn-definitive-english-patch-v2"
+        "url": "https://archive.org/details/psbbn-definitive-english-patch-v2",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN English Patch by Vitas155",
-        "url": "https://archive.org/details/bbn201311"
+        "url": "https://archive.org/details/bbn201311",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN Files on Archive.org",
-        "url": "https://archive.org/search?query=PSBBN"
+        "url": "https://archive.org/search?query=PSBBN",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN Footage (Feb 2020)",
-        "url": "https://archive.org/details/PSBBN-Footage-Feb-2020"
+        "url": "https://archive.org/details/PSBBN-Footage-Feb-2020",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN Forum Discussion",
-        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=100"
+        "url": "https://www.ps2-home.com/forum/viewtopic.php?t=100",
+        "favicon_url": "https://www.ps2-home.com/favicon.ico"
       },
       {
         "name": "PSBBN Guide",
-        "url": "https://bungiefan.tripod.com/psbbn_01.html"
+        "url": "https://bungiefan.tripod.com/psbbn_01.html",
+        "favicon_url": "https://bungiefan.tripod.com/favicon.ico"
       },
       {
         "name": "PSBBN Install Guide",
-        "url": "https://bungiefan.tripod.com/psbbninstall_01.html"
+        "url": "https://bungiefan.tripod.com/psbbninstall_01.html",
+        "favicon_url": "https://bungiefan.tripod.com/favicon.ico"
       },
       {
         "name": "PSBBN Lost Channels",
-        "url": "https://www.psx-place.com/threads/playstation-bb-lost-channels.31940/"
+        "url": "https://www.psx-place.com/threads/playstation-bb-lost-channels.31940/",
+        "favicon_url": "https://www.psx-place.com/favicon.ico"
       },
       {
         "name": "PSBBN PKGs",
-        "url": "https://archive.org/details/psbbn-pkgs"
+        "url": "https://archive.org/details/psbbn-pkgs",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "PSBBN Portal by Vitas155",
-        "url": "https://psbbn.ru/"
+        "url": "https://psbbn.ru/",
+        "favicon_url": "https://psbbn.ru/favicon.ico"
       },
       {
         "name": "PSBBN Unencrypted Loader",
-        "url": "https://archive.org/details/osdboot"
+        "url": "https://archive.org/details/osdboot",
+        "favicon_url": "https://archive.org/favicon.ico"
       },
       {
         "name": "Protokernal Patch for 10k Models",
-        "url": "https://github.com/jimmikaelkael/ps2-protokernel-patch"
+        "url": "https://github.com/jimmikaelkael/ps2-protokernel-patch",
+        "favicon_url": "https://github.com/favicon.ico"
       },
       {
         "name": "SLBB-00001",
-        "url": "https://archive.org/details/SLBB-00001"
+        "url": "https://archive.org/details/SLBB-00001",
+        "favicon_url": "https://archive.org/favicon.ico"
       }
     ]
   },
@@ -1771,95 +2199,118 @@
     "links": [
       {
         "name": "Adam Koralik's YouTube Channel",
-        "url": "https://www.youtube.com/user/AdamKoralik"
+        "url": "https://www.youtube.com/user/AdamKoralik",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Blaine Locklair's YouTube Channel",
-        "url": "https://www.youtube.com/@blainelocklair/search?query=PS2"
+        "url": "https://www.youtube.com/@blainelocklair/search?query=PS2",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "CosmicScale's YouTube Channel",
-        "url": "https://www.youtube.com/channel/UCxptXkaMSRevkUoA3rfa3aw"
+        "url": "https://www.youtube.com/channel/UCxptXkaMSRevkUoA3rfa3aw",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Daniel Santos YouTube Channel",
-        "url": "https://www.youtube.com/channel/UCIDx5TuDp-1IRTRr5l5JSdw"
+        "url": "https://www.youtube.com/channel/UCIDx5TuDp-1IRTRr5l5JSdw",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Haldrie's YouTube Channel",
-        "url": "https://www.youtube.com/Haldrie"
+        "url": "https://www.youtube.com/Haldrie",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Hardlevel's Youtube Channel",
-        "url": "https://youtube.com/hardlevelbr"
+        "url": "https://youtube.com/hardlevelbr",
+        "favicon_url": "https://youtube.com/favicon.ico"
       },
       {
         "name": "HugoPocked's YouTube Channel",
-        "url": "https://www.youtube.com/@hugopocked6695"
+        "url": "https://www.youtube.com/@hugopocked6695",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Juanky's YouTube Channel",
-        "url": "https://www.youtube.com/@JUANKYPS2"
+        "url": "https://www.youtube.com/@JUANKYPS2",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Macho Nacho Productions Youtube Channel",
-        "url": "https://www.youtube.com/@MachoNachoProductions/search?query=ps2"
+        "url": "https://www.youtube.com/@MachoNachoProductions/search?query=ps2",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "MegaBitmap's YouTube Channel",
-        "url": "https://www.youtube.com/@MegaBitmap"
+        "url": "https://www.youtube.com/@MegaBitmap",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Modern Vintage Gamer's YouTube Channel",
-        "url": "https://www.youtube.com/user/ModernVintageGamer"
+        "url": "https://www.youtube.com/user/ModernVintageGamer",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Mr. Mario2011's YouTube Channel",
-        "url": "https://www.youtube.com/@MrMario2011"
+        "url": "https://www.youtube.com/@MrMario2011",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "MyLifeinGaming's YouTube Channel",
-        "url": "https://www.youtube.com/user/MyLifeInGaming"
+        "url": "https://www.youtube.com/user/MyLifeInGaming",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Pixel Phantom's YouTube Channel",
-        "url": "https://www.youtube.com/channel/UC473GnVliV0dm5mwrR-qtsg"
+        "url": "https://www.youtube.com/channel/UC473GnVliV0dm5mwrR-qtsg",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Playstation 2 Evolution by Sony's YouTube Channel",
-        "url": "https://www.youtube.com/watch?v=Hvcps5dFzfc"
+        "url": "https://www.youtube.com/watch?v=Hvcps5dFzfc",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Prime Retro Gamer's YouTube Channel",
-        "url": "https://www.youtube.com/@PrimeRetroGamer"
+        "url": "https://www.youtube.com/@PrimeRetroGamer",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Project Pheonix Media's YouTube Channel",
-        "url": "https://www.youtube.com/@ProjectPhoenixMedia"
+        "url": "https://www.youtube.com/@ProjectPhoenixMedia",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Spaghetticode (Boon Tobias) YouTube Channel",
-        "url": "https://www.youtube.com/@Spaghetticode_Boon_Tobias"
+        "url": "https://www.youtube.com/@Spaghetticode_Boon_Tobias",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Spawn Wave's YouTube Channel",
-        "url": "https://www.youtube.com/@SpawnWave/search?query=ps2"
+        "url": "https://www.youtube.com/@SpawnWave/search?query=ps2",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "alexparrado's YouTube Channel",
-        "url": "https://www.youtube.com/@alexanderlopez-parrado3990"
+        "url": "https://www.youtube.com/@alexanderlopez-parrado3990",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "sync-on-luma's YouTube Channel",
-        "url": "https://www.youtube.com/@sync-on-luma"
+        "url": "https://www.youtube.com/@sync-on-luma",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Usagiru's YouTube Channel",
-        "url": "https://www.youtube.com/@UsagiRu_Games"
+        "url": "https://www.youtube.com/@UsagiRu_Games",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       },
       {
         "name": "Vizor's YouTube Channel",
-        "url": "https://www.youtube.com/@ViZoRRetrogames"
+        "url": "https://www.youtube.com/@ViZoRRetrogames",
+        "favicon_url": "https://www.youtube.com/favicon.ico"
       }
     ]
   }

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
-    --bg-color: #0A0A1E; /* Very dark, slightly blueish black */
-    --text-color: #E0E0E0; /* Light grey for good readability */
-    --accent-color: #0070D1; /* Classic PS2 blue */
-    --header-gradient: linear-gradient(180deg, #000010, #0A0A2A); /* Darker to slightly lighter blue/black */
-    --section-gradient: linear-gradient(90deg, #000010, #0A0A2A); /* Consistent with header */
-    --content-bg: rgba(10, 10, 30, 0.75); /* Dark translucent blue */
-    --button-gradient: linear-gradient(135deg, rgba(20, 20, 50, 0.9), rgba(0, 50, 100, 0.9)); /* PS2 blue themed buttons */
-    --footer-gradient: linear-gradient(180deg, #0A0A2A, #000010); /* Inverse of header */
-    --thanks-color: #9BB6D8; /* A lighter, softer PS2 blue */
+    --bg-color: #0a1612;
+    --text-color: #f7ce3e;
+    --accent-color: #ffd700;
+    --header-gradient: linear-gradient(180deg, #000000, #0a1612);
+    --section-gradient: linear-gradient(90deg, #000000, #0a1612);
+    --content-bg: rgba(26, 41, 48, 0.75);
+    --button-gradient: linear-gradient(135deg, #1a2930, #0a1612);
+    --footer-gradient: linear-gradient(180deg, #0a1612, #000000);
+    --thanks-color: #f7ce3e;
     --font-family: 'Roboto Mono', monospace;
     --category-max-height: 350px;
-    --scroll-track: #050510; /* Very dark for scrollbar track */
-    --scroll-thumb: #0070D1; /* Accent blue for scrollbar thumb */
+    --scroll-track: #000000;
+    --scroll-thumb: #ffd700;
     --scrollbar-width: 8px;
     --card-min-width: 280px;
     --card-max-width: 380px;
@@ -210,8 +210,7 @@ header {
     transition: left 0.3s ease;
 }
 
-#sidebar.open + header #sidebarToggle,
-#sidebar.open + #sidebarToggle {
+body.sidebar-open #sidebarToggle {
     left: calc(200px + 1rem);
 }
 
@@ -314,9 +313,8 @@ body.block-view .category {
 }
 
 .category h2 {
-    /* background: var(--section-gradient); */
     padding: 0.7rem;
-    padding-right: calc(1rem + var(--scrollbar-width));
+    padding-right: calc(1rem + var(--scrollbar-width)); /* Retain existing padding logic */
     margin: 0;
     cursor: pointer;
     font-size: 1.4rem;
@@ -324,23 +322,21 @@ body.block-view .category {
     justify-content: space-between;
     align-items: center;
     box-sizing: border-box;
-    /* border: 2px solid var(--text-color); */
-    /* border-radius: 10px; */
-    /* box-shadow: 0 0 5px rgba(0, 112, 209, 0.2); */ /* Updated accent color */
-    transition: box-shadow 0.3s ease, background-color 0.3s ease, filter 0.3s ease; /* Added filter to transition */
+    transition: background-color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 
-    background-color: var(--accent-color);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 4px;
-    box-shadow: inset 0 1px 2px rgba(255, 255, 255, 0.3), 0 1px 2px rgba(0, 0, 0, 0.3);
+    background-color: #000000; /* Black background */
+    color: var(--text-color); /* Luminous Yellow/Gold text (#f7ce3e) */
+    border: 1px solid var(--accent-color); /* Gold border (#ffd700) */
+    border-radius: 0; /* Sharp corners */
+    box-shadow: inset 0 0 3px rgba(255, 215, 0, 0.2); /* Subtle inner gold glow */
 }
 
 .category h2:hover {
-    /* box-shadow: 0 0 12px rgba(0, 112, 209, 0.5); */ /* Updated accent color */
-    /* background: rgba(0, 112, 209, 0.1); */ /* Subtle blue hover */
-    transform: translateY(-2px);
-    filter: brightness(110%);
-    box-shadow: inset 0 1px 3px rgba(255, 255, 255, 0.4), 0 2px 4px rgba(0, 0, 0, 0.4); /* Slightly enhanced shadow on hover */
+    background-color: #1a2930; /* Dark Slate Blue/Grey on hover */
+    border-color: #f7ce3e; /* Luminous Yellow/Gold border on hover */
+    box-shadow: inset 0 0 5px rgba(255, 215, 0, 0.4), 0 0 5px rgba(255, 215, 0, 0.3); /* Enhanced glow on hover */
+    transform: none; /* Remove previous transform */
+    filter: none; /* Remove previous filter */
 }
 
 .category:hover { /* Keep this subtle or match h2 hover */


### PR DESCRIPTION
This commit introduces several enhancements based on your feedback:

1.  **Sidebar Toggle Button Fix:**
    - Corrected the CSS for the sidebar toggle button (`#sidebarToggle`) to ensure it moves with the sidebar when opened/closed. It now uses the `body.sidebar-open` class for more reliable positioning.

2.  **PS2 Color Theme:**
    - Implemented a new color scheme inspired by the PlayStation 2 console.
    - Updated CSS variables in `:root` to use the new palette:
        - Background: `#0a1612` (Very Dark Green/Black)
        - Text: `#f7ce3e` (Luminous Yellow/Gold) - Accent: `#ffd700` (Gold) - Other elements (headers, footers, buttons, content areas) updated accordingly.
    - Light mode colors remain unchanged.

3.  **Redesigned Category Headers:**
    - Restyled category headers (`.category h2`) to evoke the PS2 OSDSYS (boot menu) aesthetic.
    - Headers now feature a black background, gold text and borders, sharp corners, and subtle glow effects.

4.  **Favicon URLs in `links.json`:**
    - Updated the `links.json` file to include a `favicon_url` field for every link.
    - The URL is constructed by assuming a `favicon.ico` file at the root of each link's domain (e.g., `https://domain.com/favicon.ico`).
    - The client-side JavaScript will fall back to a default favicon if the specified one is not found.