### PR TITLE
Update PWA cache name and manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "AI Services Dashboard",
-  "short_name": "AI Dashboard",
+  "name": "PS2Links",
+  "short_name": "PS2Links",
   "start_url": "index.html",
   "scope": "./",
   "display": "standalone",
@@ -8,13 +8,13 @@
   "background_color": "#1a1a1a",
   "icons": [
     {
-      "src": "icon-192x192.png",
+      "src": "../android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "icon-512x512.png",
+      "src": "../android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Bump cache version to ensure users receive the latest files
-const CACHE_NAME = 'ai-dashboard-cache-v3';
+const CACHE_NAME = 'ps2links-cache-v1';
 const URLS_TO_CACHE = [
   './index.html',
   './styles.css',


### PR DESCRIPTION
## Summary
- rename CACHE_NAME to `ps2links-cache-v1`
- set PWA manifest name to "PS2Links"
- ensure manifest icons point to existing files

## Testing
- `npm test` *(fails: browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a50c7f2508321aae07129e5cef475