### PR TITLE
Restructure links.json into category groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![image](https://github.com/user-attachments/assets/1f7709bc-493c-4f5c-9793-6466f1108e07)](https://nathanneurotic.github.io/PS2Links)
 # PS2 Resource Links
 
-PS2 Resource Links is a static collection of PlayStation 2 related sites. The page is built from `links.json` and displayed with simple JavaScript and CSS.
+PS2 Resource Links is a static collection of PlayStation 2 related sites. Link data lives in `links.json`, which now groups services under category objects, and is displayed with simple JavaScript and CSS.
 
 ## Features
 
@@ -28,7 +28,7 @@ Some browsers restrict `fetch` when using the `file://` protocol. If the links d
 python3 -m http.server 3000
 ```
 
-Then visit `http://localhost:3000/index.html` in your browser. `script.js` fetches `links.json` at page load and dynamically builds the categorized link lists.
+Then visit `http://localhost:3000/index.html` in your browser. `script.js` fetches `links.json` at page load and dynamically builds the categorized link lists from the nested data structure.
 
 ## Manual QA
 

--- a/links.json
+++ b/links.json
@@ -1,2519 +1,2374 @@
 [
   {
-    "name": "3D AI Studio",
-    "url": "https://www.3daistudio.com/",
-    "favicon_url": "https://www.3daistudio.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "modeling",
-      "design"
-    ],
-    "thumbnail_url": "https://example.com/thumbs/3d-ai-studio.png"
-  },
-  {
-    "name": "3DAIMaker",
-    "url": "https://3daimaker.com/",
-    "favicon_url": "https://3daimaker.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "creator"
-    ]
-  },
-  {
-    "name": "AI 3D Model Generator",
-    "url": "https://ai3dmodelgenerator.net/",
-    "favicon_url": "https://ai3dmodelgenerator.net/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "AITwo",
-    "url": "https://aitwo.co/",
-    "favicon_url": "https://aitwo.co/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Alpha3D",
-    "url": "https://www.alpha3d.io/",
-    "favicon_url": "https://www.alpha3d.io/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Backflip AI",
-    "url": "https://www.backflip.ai/",
-    "favicon_url": "https://www.backflip.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Bing Video Creator",
-    "url": "https://www.bing.com/images/create?&amp;ctype=video#",
-    "favicon_url": "https://www.bing.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "CGDream.ai",
-    "url": "https://cgdream.ai/",
-    "favicon_url": "https://cgdream.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Creati.ai",
-    "url": "https://creati.ai/",
-    "favicon_url": "https://creati.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "CSM AI",
-    "url": "https://www.csm.ai/",
-    "favicon_url": "https://www.csm.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "D5 Render",
-    "url": "https://www.d5render.com/",
-    "favicon_url": "https://www.d5render.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "DeepAI",
-    "url": "https://deepai.org/",
-    "favicon_url": "https://deepai.org/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "DreamFusion3D",
-    "url": "https://dreamfusion3d.github.io/",
-    "favicon_url": "https://dreamfusion3d.github.io/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Edworking 3D Model Generator",
-    "url": "https://edworking.com/ai-tools/3d-model-generator",
-    "favicon_url": "https://edworking.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Figma AI",
-    "url": "https://www.figma.com/ai/",
-    "favicon_url": "https://www.figma.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Figuro",
-    "url": "https://figuro.io/",
-    "favicon_url": "https://figuro.io/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Hunyuan3D",
-    "url": "https://hunyuan3-d.com/",
-    "favicon_url": "https://hunyuan3-d.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Hyper3D",
-    "url": "https://hyper3d.ai/",
-    "favicon_url": "https://hyper3d.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Instant3D",
-    "url": "https://www.instant3d.ai/",
-    "favicon_url": "https://www.instant3d.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Kaedim",
-    "url": "https://www.kaedim3d.com/",
-    "favicon_url": "https://www.kaedim3d.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Live3D",
-    "url": "https://live3d.io/",
-    "favicon_url": "https://live3d.io/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Luw AI",
-    "url": "https://luw.ai/",
-    "favicon_url": "https://luw.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Masterpiece X",
-    "url": "https://www.masterpiecex.com/",
-    "favicon_url": "https://www.masterpiecex.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "MazingXR",
-    "url": "https://mazingxr.com/",
-    "favicon_url": "https://mazingxr.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Meshy",
-    "url": "https://www.meshy.ai/",
-    "favicon_url": "https://www.meshy.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "NVIDIA Magic3D",
-    "url": "https://research.nvidia.com/labs/dir/magic3d/",
-    "favicon_url": "https://research.nvidia.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "PicassoIA",
-    "url": "https://picassoia.com/",
-    "favicon_url": "https://picassoia.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Pixcap",
-    "url": "https://pixcap.com/",
-    "favicon_url": "https://pixcap.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Point-E",
-    "url": "https://huggingface.co/spaces/User-2468/point-e",
-    "favicon_url": "https://openai.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "PromeAI",
-    "url": "https://www.promeai.pro/",
-    "favicon_url": "https://www.promeai.pro/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Shap-E",
-    "url": "https://huggingface.co/spaces/hysts/Shap-E",
-    "favicon_url": "https://openai.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Stable 3D",
-    "url": "https://stability.ai/stable-3d",
-    "favicon_url": "https://stability.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Tencent Hunyuan3D",
-    "url": "https://3d.hunyuan.tencent.com/",
-    "favicon_url": "https://3d.hunyuan.tencent.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "ThreeDee Design",
-    "url": "https://www.threedee.design/",
-    "favicon_url": "https://www.threedee.design/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Trellis3D",
-    "url": "https://trellis3d.ai/",
-    "favicon_url": "https://trellis3d.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Tripo3D",
-    "url": "https://www.tripo3d.ai/",
-    "favicon_url": "https://www.tripo3d.ai/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Vidu",
-    "url": "https://www.vidu.com/",
-    "favicon_url": "https://www.vidu.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "Vondy",
-    "url": "https://www.vondy.com/",
-    "favicon_url": "https://www.vondy.com/favicon.ico",
-    "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
-    ]
-  },
-  {
-    "name": "AGRIVI",
-    "url": "https://www.agrivi.com/",
-    "favicon_url": "https://www.agrivi.com/favicon.ico",
-    "category": "🌲 Agriculture",
-    "tags": [
-      "agriculture"
-    ]
-  },
-  {
-    "name": "CattleEye",
-    "url": "https://www.cattleeye.com/",
-    "favicon_url": "https://www.cattleeye.com/favicon.ico",
-    "category": "🌲 Agriculture",
-    "tags": [
-      "agriculture"
-    ]
-  },
-  {
-    "name": "Krishi Mitra",
-    "url": "https://www.itcagr.com/krishi-mitra",
-    "favicon_url": "https://www.itcagr.com/favicon.ico",
-    "category": "🌲 Agriculture",
-    "tags": [
-      "agriculture"
-    ]
-  },
-  {
-    "name": "Robovision",
-    "url": "https://robovision.ai/",
-    "favicon_url": "https://robovision.ai/favicon.ico",
-    "category": "🌲 Agriculture",
-    "tags": [
-      "agriculture"
-    ]
-  },
-  {
-    "name": "AI Pool Tools",
-    "url": "https://tools.aipoool.com/",
-    "favicon_url": "./favicon.ico",
-    "category": "📚 Articles and Reviews",
-    "tags": [
-      "articles",
-      "reviews"
-    ]
-  },
-  {
-    "name": "SongBeast AI Review by Decortweaks",
-    "url": "https://decortweaks.com/songbeast-ai-review/",
-    "favicon_url": "./favicon.ico",
-    "category": "📚 Articles and Reviews",
-    "tags": [
-      "articles",
-      "reviews"
-    ]
-  },
-  {
-    "name": "Character AI",
-    "url": "https://character.ai/",
-    "favicon_url": "https://character.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "ChatGPT",
-    "url": "https://www.chatgpt.com/",
-    "favicon_url": "https://www.chatgpt.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Claude",
-    "url": "https://claude.ai/new",
-    "favicon_url": "https://claude.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "anthropic",
-      "chatbot"
-    ]
-  },
-  {
-    "name": "Copy.ai",
-    "url": "https://www.copy.ai/",
-    "favicon_url": "https://www.copy.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "DeepSeek",
-    "url": "https://chat.deepseek.com/",
-    "favicon_url": "https://deepseek.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Google Gemini",
-    "url": "https://gemini.google.com/",
-    "favicon_url": "https://gemini.google.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Grok",
-    "url": "https://www.grok.com/",
-    "favicon_url": "https://www.grok.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Grok API",
-    "url": "https://x.ai/api",
-    "favicon_url": "https://x.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Grok Voice",
-    "url": "https://x.ai/grok-voice",
-    "favicon_url": "https://x.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Inflection AI",
-    "url": "https://developers.inflection.ai/login",
-    "favicon_url": "https://developers.inflection.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Intercom AI",
-    "url": "https://www.intercom.com/ai",
-    "favicon_url": "https://www.intercom.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Jasper",
-    "url": "https://www.jasper.ai/",
-    "favicon_url": "https://www.jasper.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "thumbnail_url": "https://example.com/thumbs/jasper.png",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Meta AI",
-    "url": "https://www.meta.ai/",
-    "favicon_url": "https://www.meta.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Microsoft Copilot",
-    "url": "https://copilot.microsoft.com/",
-    "favicon_url": "https://copilot.microsoft.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Minimax Chat",
-    "url": "https://chat.minimax.io/",
-    "favicon_url": "https://chat.minimax.io/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Mistral AI",
-    "url": "https://chat.mistral.ai/chat",
-    "favicon_url": "https://chat.mistral.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Notion AI",
-    "url": "https://www.notion.so/product/ai",
-    "favicon_url": "https://www.notion.so/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Perplexity",
-    "url": "https://www.perplexity.ai/",
-    "favicon_url": "https://www.perplexity.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Poe",
-    "url": "https://poe.com/",
-    "favicon_url": "https://poe.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Qwen",
-    "url": "https://chat.qwen.ai/",
-    "favicon_url": "https://chat.qwen.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Rytr",
-    "url": "https://rytr.me/",
-    "favicon_url": "https://rytr.me/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Sudowrite",
-    "url": "https://www.sudowrite.com/",
-    "favicon_url": "https://www.sudowrite.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Writer.com",
-    "url": "https://writer.com/",
-    "favicon_url": "https://writer.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "writing"
-    ]
-  },
-  {
-    "name": "Writesonic",
-    "url": "https://writesonic.com/",
-    "favicon_url": "https://writesonic.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "xAI Chat",
-    "url": "https://x.ai/chat",
-    "favicon_url": "https://x.ai/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "Zendesk AI",
-    "url": "https://www.zendesk.com/ai",
-    "favicon_url": "https://www.zendesk.com/favicon.ico",
-    "category": "👽 All-in-One",
-    "tags": [
-      "allinone"
-    ]
-  },
-  {
-    "name": "AIVA",
-    "url": "https://www.aiva.ai/",
-    "favicon_url": "https://www.aiva.ai/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "AssemblyAI",
-    "url": "https://www.assemblyai.com/",
-    "favicon_url": "https://www.assemblyai.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "ElevenLabs",
-    "url": "https://elevenlabs.io/app/home",
-    "favicon_url": "https://elevenlabs.io/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Freebeat.ai",
-    "url": "https://freebeat.ai/",
-    "favicon_url": "https://freebeat.ai/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Landr",
-    "url": "https://app.landr.com/",
-    "favicon_url": "https://app.landr.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Mubert",
-    "url": "https://mubert.com/",
-    "favicon_url": "https://mubert.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Murf.ai",
-    "url": "https://murf.ai/",
-    "favicon_url": "https://murf.ai/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Play.ht",
-    "url": "https://play.ht/",
-    "favicon_url": "https://play.ht/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "SongBeast AI",
-    "url": "https://songbeastai.com/",
-    "favicon_url": "https://songbeastai.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "SoundGen.io",
-    "url": "https://soundgen.io/",
-    "favicon_url": "https://soundgen.io/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Soundraw",
-    "url": "https://soundraw.io/",
-    "favicon_url": "https://soundraw.io/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Suno",
-    "url": "https://suno.com/invite/@nathanneurotic",
-    "favicon_url": "https://suno.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Suno Create",
-    "url": "https://suno.com/create?wid=default",
-    "favicon_url": "https://suno.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Synthesizer V",
-    "url": "https://dreamtonics.com/synthesizerv/",
-    "favicon_url": "https://dreamtonics.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Udio",
-    "url": "https://www.udio.com/creators/NathanNeurotic",
-    "favicon_url": "https://www.udio.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Udio Create",
-    "url": "https://www.udio.com/create",
-    "favicon_url": "https://www.udio.com/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
-    ]
-  },
-  {
-    "name": "Voicemod AI Voices",
-    "url": "https://www.voicemod.net/ai-voices/",
-    "favicon_url": "https://www.voicemod.net/favicon.ico",
-    "category": "🔊 Audio, Music, and Speech",
-    "tags": [
-      "audio",
-      "music",
-      "speech"
+    "category": "✨ Google Ecosystem",
+    "links": [
+      {
+        "name": "AI Google",
+        "url": "https://ai.google/",
+        "favicon_url": "https://ai.google/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Cloud",
+        "url": "https://cloud.google.com/",
+        "favicon_url": "https://cloud.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Code",
+        "url": "https://code.google.com/",
+        "favicon_url": "https://code.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Code Archive",
+        "url": "https://code.google.com/archive/",
+        "favicon_url": "https://code.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google DeepMind",
+        "url": "https://deepmind.google/",
+        "favicon_url": "https://deepmind.google/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Labs",
+        "url": "https://labs.google.com/",
+        "favicon_url": "https://labs.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Labs Experiments",
+        "url": "https://labs.google.com/experiments",
+        "favicon_url": "https://labs.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Labs Search",
+        "url": "https://labs.google.com/search/",
+        "favicon_url": "https://labs.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Labs Sessions",
+        "url": "https://labs.google.com/sessions",
+        "favicon_url": "https://labs.google.com/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Open Source",
+        "url": "https://opensource.google/",
+        "favicon_url": "https://opensource.google/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Google Research",
+        "url": "https://research.google/",
+        "favicon_url": "https://research.google/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "NotebookLM",
+        "url": "https://notebooklm.google/",
+        "favicon_url": "https://notebooklm.google/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      },
+      {
+        "name": "Veo",
+        "url": "https://deepmind.google/technologies/veo/",
+        "favicon_url": "https://deepmind.google/favicon.ico",
+        "tags": [
+          "google",
+          "ecosystem"
+        ]
+      }
     ]
   },
   {
-    "name": "ClimateAI",
-    "url": "https://www.climate.ai/",
-    "favicon_url": "https://www.climate.ai/favicon.ico",
     "category": "🌎 Climate",
-    "tags": [
-      "climate"
+    "links": [
+      {
+        "name": "ClimateAI",
+        "url": "https://www.climate.ai/",
+        "favicon_url": "https://www.climate.ai/favicon.ico",
+        "tags": [
+          "climate"
+        ]
+      },
+      {
+        "name": "Pachama",
+        "url": "https://www.pachama.com/",
+        "favicon_url": "https://www.pachama.com/favicon.ico",
+        "tags": [
+          "climate"
+        ]
+      }
     ]
   },
   {
-    "name": "Pachama",
-    "url": "https://www.pachama.com/",
-    "favicon_url": "https://www.pachama.com/favicon.ico",
-    "category": "🌎 Climate",
-    "tags": [
-      "climate"
-    ]
-  },
-  {
-    "name": "Bolt.new",
-    "url": "https://bolt.new/",
-    "favicon_url": "https://bolt.new/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Codeium",
-    "url": "https://codeium.com/",
-    "favicon_url": "https://codeium.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Codex by OpenAI",
-    "url": "https://chatgpt.com/codex",
-    "favicon_url": "https://chatgpt.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Codota",
-    "url": "https://www.tabnine.com/",
-    "favicon_url": "https://www.tabnine.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Cursor",
-    "url": "https://www.cursor.com/",
-    "favicon_url": "https://www.cursor.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "DeepCode",
-    "url": "https://www.snyk.io/deepcode/",
-    "favicon_url": "https://www.snyk.io/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "GitHub Copilot",
-    "url": "https://github.com/features/copilot",
-    "favicon_url": "https://github.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "GitHub Copilot Repo",
-    "url": "https://github.com/copilot",
-    "favicon_url": "https://github.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Google Code Assist",
-    "url": "https://codeassist.google.com/",
-    "favicon_url": "https://codeassist.google.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "thumbnail_url": "https://example.com/thumbs/google-code-assist.png",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Jules",
-    "url": "https://jules.google.com/",
-    "favicon_url": "https://jules.google.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Phind",
-    "url": "https://www.phind.com/",
-    "favicon_url": "https://www.phind.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Qodex",
-    "url": "https://www.qodex.ai/",
-    "favicon_url": "https://www.qodex.ai/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "Replit",
-    "url": "https://replit.com/",
-    "favicon_url": "https://replit.com/favicon.ico",
-    "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
-    ]
-  },
-  {
-    "name": "AI21 Labs",
-    "url": "https://www.ai21.com/",
-    "favicon_url": "https://www.ai21.com/favicon.ico",
     "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
+    "links": [
+      {
+        "name": "AI21 Labs",
+        "url": "https://www.ai21.com/",
+        "favicon_url": "https://www.ai21.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Amazon SageMaker",
+        "url": "https://aws.amazon.com/sagemaker/",
+        "favicon_url": "https://aws.amazon.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Azure AI Services",
+        "url": "https://azure.microsoft.com/en-us/products/ai-services/",
+        "favicon_url": "https://azure.microsoft.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Clarifai",
+        "url": "https://www.clarifai.com/",
+        "favicon_url": "https://www.clarifai.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Cohere",
+        "url": "https://cohere.com/",
+        "favicon_url": "https://cohere.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Cortical",
+        "url": "https://www.cortical.io/",
+        "favicon_url": "https://www.cortical.io/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Databricks (Mosaic AI)",
+        "url": "https://www.databricks.com/product/ai",
+        "favicon_url": "https://www.databricks.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "DataRobot",
+        "url": "https://www.datarobot.com/",
+        "favicon_url": "https://www.datarobot.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Gemini API Docs (Garden)",
+        "url": "https://ai.google.dev/gemini-api/docs?utm_source=gfd&amp;utm_medium=referral&amp;utm_campaign=ai_logo_garden&amp;utm_content",
+        "favicon_url": "https://ai.google.dev/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Gemini Nano (Android)",
+        "url": "https://developer.android.com/ai/gemini-nano",
+        "favicon_url": "https://developer.android.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google AI Edge",
+        "url": "https://ai.google.dev/edge",
+        "favicon_url": "https://ai.google.dev/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google AI Studio",
+        "url": "https://aistudio.google.com/prompts/new_chat",
+        "favicon_url": "https://aistudio.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google AI Studio (Garden)",
+        "url": "https://aistudio.google.com/app/prompts/new_chat?utm_source=gfd&amp;utm_medium=referral&amp;utm_campaign=home_garden&amp;utm_content=",
+        "favicon_url": "https://aistudio.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google Cloud Shell",
+        "url": "https://shell.cloud.google.com/",
+        "favicon_url": "https://shell.cloud.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google Cloud Solutions Catalog",
+        "url": "https://console.cloud.google.com/products/solutions/catalog?inv=1&amp;invt=Aby_hw&amp;project=engaged-timing-jxcbk",
+        "favicon_url": "https://console.cloud.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google Developers",
+        "url": "https://developers.google.com/",
+        "favicon_url": "https://developers.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google Home Projects Console",
+        "url": "https://console.home.google.com/projects?pli=1",
+        "favicon_url": "https://console.home.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google Vertex AI",
+        "url": "https://console.cloud.google.com/vertex-ai/studio/overview",
+        "favicon_url": "https://console.cloud.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Google Vertex AI Studio (Engaged)",
+        "url": "https://console.cloud.google.com/vertex-ai/studio/overview?inv=1&amp;invt=Aby_kQ&amp;project=engaged-timing-jxcbk",
+        "favicon_url": "https://console.cloud.google.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Hume AI",
+        "url": "https://www.hume.ai/",
+        "favicon_url": "https://www.hume.ai/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Minimax",
+        "url": "https://www.minimax.io/",
+        "favicon_url": "https://www.minimax.io/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Ollama",
+        "url": "https://ollama.com/",
+        "favicon_url": "https://ollama.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Salesforce Einstein / AI Cloud",
+        "url": "https://www.salesforce.com/products/ai-cloud/overview/",
+        "favicon_url": "https://www.salesforce.com/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Stability AI",
+        "url": "https://stability.ai/",
+        "favicon_url": "https://stability.ai/favicon.ico",
+        "tags": [
+          "developer",
+          "platforms",
+          "apis"
+        ]
+      },
+      {
+        "name": "Hugging Face",
+        "url": "https://huggingface.co/",
+        "favicon_url": "https://huggingface.co/favicon.ico",
+        "tags": [
+          "datasets",
+          "models",
+          "transformers"
+        ]
+      }
     ]
   },
   {
-    "name": "Amazon SageMaker",
-    "url": "https://aws.amazon.com/sagemaker/",
-    "favicon_url": "https://aws.amazon.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
+    "category": "🌲 Agriculture",
+    "links": [
+      {
+        "name": "AGRIVI",
+        "url": "https://www.agrivi.com/",
+        "favicon_url": "https://www.agrivi.com/favicon.ico",
+        "tags": [
+          "agriculture"
+        ]
+      },
+      {
+        "name": "CattleEye",
+        "url": "https://www.cattleeye.com/",
+        "favicon_url": "https://www.cattleeye.com/favicon.ico",
+        "tags": [
+          "agriculture"
+        ]
+      },
+      {
+        "name": "Krishi Mitra",
+        "url": "https://www.itcagr.com/krishi-mitra",
+        "favicon_url": "https://www.itcagr.com/favicon.ico",
+        "tags": [
+          "agriculture"
+        ]
+      },
+      {
+        "name": "Robovision",
+        "url": "https://robovision.ai/",
+        "favicon_url": "https://robovision.ai/favicon.ico",
+        "tags": [
+          "agriculture"
+        ]
+      }
     ]
   },
   {
-    "name": "Azure AI Services",
-    "url": "https://azure.microsoft.com/en-us/products/ai-services/",
-    "favicon_url": "https://azure.microsoft.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
+    "category": "🎨 Image Generation and Design",
+    "links": [
+      {
+        "name": "Adobe Firefly",
+        "url": "https://www.adobe.com/products/firefly/landpa.html",
+        "favicon_url": "https://www.adobe.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Artbreeder",
+        "url": "https://www.artbreeder.com/",
+        "favicon_url": "https://www.artbreeder.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Bing Image Creator",
+        "url": "https://www.bing.com/images/create",
+        "favicon_url": "https://www.bing.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Canva AI",
+        "url": "https://www.canva.com/ai/",
+        "favicon_url": "https://www.canva.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Craiyon",
+        "url": "https://www.craiyon.com/",
+        "favicon_url": "https://www.craiyon.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "D-ID",
+        "url": "https://www.d-id.com/pricing/studio/",
+        "favicon_url": "https://www.d-id.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "DALL-E",
+        "url": "https://openai.com/dall-e",
+        "favicon_url": "https://openai.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "DaVinci AI",
+        "url": "https://davinci.ai/app",
+        "favicon_url": "https://davinci.ai/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Flux",
+        "url": "https://www.fal.ai/flux",
+        "favicon_url": "https://www.fal.ai/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Higgsfield AI",
+        "url": "https://higgsfield.ai/",
+        "favicon_url": "https://higgsfield.ai/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Ideogram",
+        "url": "https://ideogram.ai/",
+        "favicon_url": "https://ideogram.ai/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Leonardo AI",
+        "url": "https://app.leonardo.ai/",
+        "favicon_url": "https://app.leonardo.ai/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Microsoft Designer",
+        "url": "https://designer.microsoft.com/",
+        "favicon_url": "https://designer.microsoft.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "MidJourney",
+        "url": "https://www.midjourney.com/explore?tab=top_month",
+        "favicon_url": "https://www.midjourney.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "NightCafe",
+        "url": "https://nightcafe.studio/",
+        "favicon_url": "https://nightcafe.studio/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "OpenArt",
+        "url": "https://openart.ai/",
+        "favicon_url": "https://openart.ai/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      },
+      {
+        "name": "Stable Diffusion",
+        "url": "https://stablediffusionweb.com/",
+        "favicon_url": "https://stablediffusionweb.com/favicon.ico",
+        "tags": [
+          "image",
+          "generation",
+          "design"
+        ]
+      }
     ]
   },
   {
-    "name": "Clarifai",
-    "url": "https://www.clarifai.com/",
-    "favicon_url": "https://www.clarifai.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
+    "category": "🎬 Video Generation and Editing",
+    "links": [
+      {
+        "name": "CapCut",
+        "url": "https://www.capcut.com/",
+        "favicon_url": "https://www.capcut.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Clipchamp",
+        "url": "https://clipchamp.com/",
+        "favicon_url": "https://clipchamp.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Descript",
+        "url": "https://www.descript.com/",
+        "favicon_url": "https://www.descript.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "FlexClip",
+        "url": "https://www.flexclip.com/",
+        "favicon_url": "https://www.flexclip.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Hailuo AI",
+        "url": "https://hailuoai.video/",
+        "favicon_url": "https://hailuoai.video/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Hailuo AI Subscribe",
+        "url": "https://hailuoai.video/subscribe",
+        "favicon_url": "https://hailuoai.video/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Invideo AI",
+        "url": "https://invideo.io/",
+        "favicon_url": "https://invideo.io/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Jogg.ai",
+        "url": "https://www.jogg.ai/",
+        "favicon_url": "https://www.jogg.ai/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Kaiber",
+        "url": "https://kaiber.ai/",
+        "favicon_url": "https://kaiber.ai/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Kling AI",
+        "url": "https://www.klingai.com/",
+        "favicon_url": "https://www.klingai.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "LTX Studio",
+        "url": "https://app.ltx.studio/",
+        "favicon_url": "https://ltx.studio/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Neural Frames",
+        "url": "https://www.neuralframes.com/",
+        "favicon_url": "https://www.neuralframes.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Opus Clip",
+        "url": "https://www.opus.pro/",
+        "favicon_url": "https://www.opus.pro/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Pictory AI",
+        "url": "https://app.pictory.ai/",
+        "favicon_url": "https://pictory.ai/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Pika",
+        "url": "https://pika.art/login",
+        "favicon_url": "https://pika.art/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Plazmapunk",
+        "url": "https://app.plazmapunk.com/",
+        "favicon_url": "https://plazmapunk.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Revid AI",
+        "url": "https://www.revid.ai/",
+        "favicon_url": "https://www.revid.ai/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "RunwayML",
+        "url": "https://app.runwayml.com/",
+        "favicon_url": "https://app.runwayml.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Sora",
+        "url": "https://sora.chatgpt.com/",
+        "favicon_url": "https://sora.chatgpt.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Synthesia",
+        "url": "https://www.synthesia.io/",
+        "favicon_url": "https://www.synthesia.io/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Veed.io",
+        "url": "https://www.veed.io/",
+        "favicon_url": "https://www.veed.io/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Veo-2",
+        "url": "https://deepmind.google/technologies/veo/",
+        "favicon_url": "https://deepmind.google/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      },
+      {
+        "name": "Vidnoz AI",
+        "url": "https://aiapp.vidnoz.com/",
+        "favicon_url": "https://vidnoz.com/favicon.ico",
+        "tags": [
+          "video",
+          "generation",
+          "editing"
+        ]
+      }
     ]
   },
   {
-    "name": "Cohere",
-    "url": "https://cohere.com/",
-    "favicon_url": "https://cohere.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
+    "category": "🎮 Games",
+    "links": [
+      {
+        "name": "Convai",
+        "url": "https://www.convai.com/",
+        "favicon_url": "https://www.convai.com/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      },
+      {
+        "name": "Flawless AI",
+        "url": "https://www.flawlessai.com/",
+        "favicon_url": "https://www.flawlessai.com/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      },
+      {
+        "name": "Inworld AI",
+        "url": "https://www.inworld.ai/",
+        "favicon_url": "https://www.inworld.ai/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      },
+      {
+        "name": "Luma AI Genie",
+        "url": "https://lumalabs.ai/genie",
+        "favicon_url": "https://lumalabs.ai/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      },
+      {
+        "name": "Promethean AI",
+        "url": "https://www.prometheanai.com/",
+        "favicon_url": "https://www.prometheanai.com/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      },
+      {
+        "name": "Rosebud AI",
+        "url": "https://www.rosebud.ai/",
+        "favicon_url": "https://www.rosebud.ai/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      },
+      {
+        "name": "Scenario",
+        "url": "https://www.scenario.com/",
+        "favicon_url": "https://www.scenario.com/favicon.ico",
+        "tags": [
+          "games"
+        ]
+      }
     ]
   },
   {
-    "name": "Cortical",
-    "url": "https://www.cortical.io/",
-    "favicon_url": "https://www.cortical.io/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
+    "category": "👽 All-in-One",
+    "links": [
+      {
+        "name": "Character AI",
+        "url": "https://character.ai/",
+        "favicon_url": "https://character.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "ChatGPT",
+        "url": "https://www.chatgpt.com/",
+        "favicon_url": "https://www.chatgpt.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Claude",
+        "url": "https://claude.ai/new",
+        "favicon_url": "https://claude.ai/favicon.ico",
+        "tags": [
+          "anthropic",
+          "chatbot"
+        ]
+      },
+      {
+        "name": "Copy.ai",
+        "url": "https://www.copy.ai/",
+        "favicon_url": "https://www.copy.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "DeepSeek",
+        "url": "https://chat.deepseek.com/",
+        "favicon_url": "https://deepseek.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Google Gemini",
+        "url": "https://gemini.google.com/",
+        "favicon_url": "https://gemini.google.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Grok",
+        "url": "https://www.grok.com/",
+        "favicon_url": "https://www.grok.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Grok API",
+        "url": "https://x.ai/api",
+        "favicon_url": "https://x.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Grok Voice",
+        "url": "https://x.ai/grok-voice",
+        "favicon_url": "https://x.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Inflection AI",
+        "url": "https://developers.inflection.ai/login",
+        "favicon_url": "https://developers.inflection.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Intercom AI",
+        "url": "https://www.intercom.com/ai",
+        "favicon_url": "https://www.intercom.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Jasper",
+        "url": "https://www.jasper.ai/",
+        "favicon_url": "https://www.jasper.ai/favicon.ico",
+        "thumbnail_url": "https://example.com/thumbs/jasper.png",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Meta AI",
+        "url": "https://www.meta.ai/",
+        "favicon_url": "https://www.meta.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Microsoft Copilot",
+        "url": "https://copilot.microsoft.com/",
+        "favicon_url": "https://copilot.microsoft.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Minimax Chat",
+        "url": "https://chat.minimax.io/",
+        "favicon_url": "https://chat.minimax.io/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Mistral AI",
+        "url": "https://chat.mistral.ai/chat",
+        "favicon_url": "https://chat.mistral.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Notion AI",
+        "url": "https://www.notion.so/product/ai",
+        "favicon_url": "https://www.notion.so/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Perplexity",
+        "url": "https://www.perplexity.ai/",
+        "favicon_url": "https://www.perplexity.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Poe",
+        "url": "https://poe.com/",
+        "favicon_url": "https://poe.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Qwen",
+        "url": "https://chat.qwen.ai/",
+        "favicon_url": "https://chat.qwen.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Rytr",
+        "url": "https://rytr.me/",
+        "favicon_url": "https://rytr.me/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Sudowrite",
+        "url": "https://www.sudowrite.com/",
+        "favicon_url": "https://www.sudowrite.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Writer.com",
+        "url": "https://writer.com/",
+        "favicon_url": "https://writer.com/favicon.ico",
+        "tags": [
+          "writing"
+        ]
+      },
+      {
+        "name": "Writesonic",
+        "url": "https://writesonic.com/",
+        "favicon_url": "https://writesonic.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "xAI Chat",
+        "url": "https://x.ai/chat",
+        "favicon_url": "https://x.ai/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      },
+      {
+        "name": "Zendesk AI",
+        "url": "https://www.zendesk.com/ai",
+        "favicon_url": "https://www.zendesk.com/favicon.ico",
+        "tags": [
+          "allinone"
+        ]
+      }
     ]
   },
   {
-    "name": "Databricks (Mosaic AI)",
-    "url": "https://www.databricks.com/product/ai",
-    "favicon_url": "https://www.databricks.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "DataRobot",
-    "url": "https://www.datarobot.com/",
-    "favicon_url": "https://www.datarobot.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Gemini API Docs (Garden)",
-    "url": "https://ai.google.dev/gemini-api/docs?utm_source=gfd&amp;utm_medium=referral&amp;utm_campaign=ai_logo_garden&amp;utm_content",
-    "favicon_url": "https://ai.google.dev/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Gemini Nano (Android)",
-    "url": "https://developer.android.com/ai/gemini-nano",
-    "favicon_url": "https://developer.android.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google AI Edge",
-    "url": "https://ai.google.dev/edge",
-    "favicon_url": "https://ai.google.dev/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google AI Studio",
-    "url": "https://aistudio.google.com/prompts/new_chat",
-    "favicon_url": "https://aistudio.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google AI Studio (Garden)",
-    "url": "https://aistudio.google.com/app/prompts/new_chat?utm_source=gfd&amp;utm_medium=referral&amp;utm_campaign=home_garden&amp;utm_content=",
-    "favicon_url": "https://aistudio.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google Cloud Shell",
-    "url": "https://shell.cloud.google.com/",
-    "favicon_url": "https://shell.cloud.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google Cloud Solutions Catalog",
-    "url": "https://console.cloud.google.com/products/solutions/catalog?inv=1&amp;invt=Aby_hw&amp;project=engaged-timing-jxcbk",
-    "favicon_url": "https://console.cloud.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google Developers",
-    "url": "https://developers.google.com/",
-    "favicon_url": "https://developers.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google Home Projects Console",
-    "url": "https://console.home.google.com/projects?pli=1",
-    "favicon_url": "https://console.home.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google Vertex AI",
-    "url": "https://console.cloud.google.com/vertex-ai/studio/overview",
-    "favicon_url": "https://console.cloud.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Google Vertex AI Studio (Engaged)",
-    "url": "https://console.cloud.google.com/vertex-ai/studio/overview?inv=1&amp;invt=Aby_kQ&amp;project=engaged-timing-jxcbk",
-    "favicon_url": "https://console.cloud.google.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Hume AI",
-    "url": "https://www.hume.ai/",
-    "favicon_url": "https://www.hume.ai/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Minimax",
-    "url": "https://www.minimax.io/",
-    "favicon_url": "https://www.minimax.io/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Ollama",
-    "url": "https://ollama.com/",
-    "favicon_url": "https://ollama.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Salesforce Einstein / AI Cloud",
-    "url": "https://www.salesforce.com/products/ai-cloud/overview/",
-    "favicon_url": "https://www.salesforce.com/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Stability AI",
-    "url": "https://stability.ai/",
-    "favicon_url": "https://stability.ai/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "developer",
-      "platforms",
-      "apis"
-    ]
-  },
-  {
-    "name": "Enel X",
-    "url": "https://www.enelx.com/",
-    "favicon_url": "https://www.enelx.com/favicon.ico",
     "category": "💡 Energy",
-    "tags": [
-      "energy"
+    "links": [
+      {
+        "name": "Enel X",
+        "url": "https://www.enelx.com/",
+        "favicon_url": "https://www.enelx.com/favicon.ico",
+        "tags": [
+          "energy"
+        ]
+      },
+      {
+        "name": "Stem AI",
+        "url": "https://www.stem.com/",
+        "favicon_url": "https://www.stem.com/favicon.ico",
+        "tags": [
+          "energy"
+        ]
+      }
     ]
   },
   {
-    "name": "Stem AI",
-    "url": "https://www.stem.com/",
-    "favicon_url": "https://www.stem.com/favicon.ico",
-    "category": "💡 Energy",
-    "tags": [
-      "energy"
-    ]
-  },
-  {
-    "name": "Kasisto",
-    "url": "https://kasisto.com/",
-    "favicon_url": "https://kasisto.com/favicon.ico",
     "category": "💰 Financial",
-    "tags": [
-      "financial"
+    "links": [
+      {
+        "name": "Kasisto",
+        "url": "https://kasisto.com/",
+        "favicon_url": "https://kasisto.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      },
+      {
+        "name": "Klarna AI",
+        "url": "https://www.klarna.com/ai/",
+        "favicon_url": "https://www.klarna.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      },
+      {
+        "name": "Personetics",
+        "url": "https://personetics.com/",
+        "favicon_url": "https://personetics.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      },
+      {
+        "name": "Plaid AI",
+        "url": "https://plaid.com/ai/",
+        "favicon_url": "https://plaid.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      },
+      {
+        "name": "Stripe AI",
+        "url": "https://stripe.com/ai",
+        "favicon_url": "https://stripe.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      },
+      {
+        "name": "Upstart",
+        "url": "https://www.upstart.com/",
+        "favicon_url": "https://www.upstart.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      },
+      {
+        "name": "Wealthfront",
+        "url": "https://www.wealthfront.com/",
+        "favicon_url": "https://www.wealthfront.com/favicon.ico",
+        "tags": [
+          "financial"
+        ]
+      }
     ]
   },
   {
-    "name": "Klarna AI",
-    "url": "https://www.klarna.com/ai/",
-    "favicon_url": "https://www.klarna.com/favicon.ico",
-    "category": "💰 Financial",
-    "tags": [
-      "financial"
-    ]
-  },
-  {
-    "name": "Personetics",
-    "url": "https://personetics.com/",
-    "favicon_url": "https://personetics.com/favicon.ico",
-    "category": "💰 Financial",
-    "tags": [
-      "financial"
-    ]
-  },
-  {
-    "name": "Plaid AI",
-    "url": "https://plaid.com/ai/",
-    "favicon_url": "https://plaid.com/favicon.ico",
-    "category": "💰 Financial",
-    "tags": [
-      "financial"
-    ]
-  },
-  {
-    "name": "Stripe AI",
-    "url": "https://stripe.com/ai",
-    "favicon_url": "https://stripe.com/favicon.ico",
-    "category": "💰 Financial",
-    "tags": [
-      "financial"
-    ]
-  },
-  {
-    "name": "Upstart",
-    "url": "https://www.upstart.com/",
-    "favicon_url": "https://www.upstart.com/favicon.ico",
-    "category": "💰 Financial",
-    "tags": [
-      "financial"
-    ]
-  },
-  {
-    "name": "Wealthfront",
-    "url": "https://www.wealthfront.com/",
-    "favicon_url": "https://www.wealthfront.com/favicon.ico",
-    "category": "💰 Financial",
-    "tags": [
-      "financial"
-    ]
-  },
-  {
-    "name": "Convai",
-    "url": "https://www.convai.com/",
-    "favicon_url": "https://www.convai.com/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "Flawless AI",
-    "url": "https://www.flawlessai.com/",
-    "favicon_url": "https://www.flawlessai.com/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "Inworld AI",
-    "url": "https://www.inworld.ai/",
-    "favicon_url": "https://www.inworld.ai/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "Luma AI Genie",
-    "url": "https://lumalabs.ai/genie",
-    "favicon_url": "https://lumalabs.ai/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "Promethean AI",
-    "url": "https://www.prometheanai.com/",
-    "favicon_url": "https://www.prometheanai.com/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "Rosebud AI",
-    "url": "https://www.rosebud.ai/",
-    "favicon_url": "https://www.rosebud.ai/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "Scenario",
-    "url": "https://www.scenario.com/",
-    "favicon_url": "https://www.scenario.com/favicon.ico",
-    "category": "🎮 Games",
-    "tags": [
-      "games"
-    ]
-  },
-  {
-    "name": "AI Google",
-    "url": "https://ai.google/",
-    "favicon_url": "https://ai.google/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Cloud",
-    "url": "https://cloud.google.com/",
-    "favicon_url": "https://cloud.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Code",
-    "url": "https://code.google.com/",
-    "favicon_url": "https://code.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Code Archive",
-    "url": "https://code.google.com/archive/",
-    "favicon_url": "https://code.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google DeepMind",
-    "url": "https://deepmind.google/",
-    "favicon_url": "https://deepmind.google/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Labs",
-    "url": "https://labs.google.com/",
-    "favicon_url": "https://labs.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Labs Experiments",
-    "url": "https://labs.google.com/experiments",
-    "favicon_url": "https://labs.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Labs Search",
-    "url": "https://labs.google.com/search/",
-    "favicon_url": "https://labs.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Labs Sessions",
-    "url": "https://labs.google.com/sessions",
-    "favicon_url": "https://labs.google.com/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Open Source",
-    "url": "https://opensource.google/",
-    "favicon_url": "https://opensource.google/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Google Research",
-    "url": "https://research.google/",
-    "favicon_url": "https://research.google/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "NotebookLM",
-    "url": "https://notebooklm.google/",
-    "favicon_url": "https://notebooklm.google/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Veo",
-    "url": "https://deepmind.google/technologies/veo/",
-    "favicon_url": "https://deepmind.google/favicon.ico",
-    "category": "✨ Google Ecosystem",
-    "tags": [
-      "google",
-      "ecosystem"
-    ]
-  },
-  {
-    "name": "Aidoc",
-    "url": "https://www.aidoc.com/",
-    "favicon_url": "https://www.aidoc.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "DeepMind Health",
-    "url": "https://www.deepmind.com/health",
-    "favicon_url": "https://www.deepmind.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "Merative",
-    "url": "https://www.merative.com/",
-    "favicon_url": "https://www.merative.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "PathAI",
-    "url": "https://www.pathai.com/",
-    "favicon_url": "https://www.pathai.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "Tempus",
-    "url": "https://www.tempus.com/",
-    "favicon_url": "https://www.tempus.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "Viz.ai",
-    "url": "https://www.viz.ai/",
-    "favicon_url": "https://www.viz.ai/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "Welltok",
-    "url": "https://www.welltok.com/",
-    "favicon_url": "https://www.welltok.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "XpertDox",
-    "url": "https://www.xpertdox.com/",
-    "favicon_url": "https://www.xpertdox.com/favicon.ico",
-    "category": "🩺 Healthcare",
-    "tags": [
-      "healthcare"
-    ]
-  },
-  {
-    "name": "Adobe Firefly",
-    "url": "https://www.adobe.com/products/firefly/landpa.html",
-    "favicon_url": "https://www.adobe.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Artbreeder",
-    "url": "https://www.artbreeder.com/",
-    "favicon_url": "https://www.artbreeder.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Bing Image Creator",
-    "url": "https://www.bing.com/images/create",
-    "favicon_url": "https://www.bing.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Canva AI",
-    "url": "https://www.canva.com/ai/",
-    "favicon_url": "https://www.canva.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Craiyon",
-    "url": "https://www.craiyon.com/",
-    "favicon_url": "https://www.craiyon.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "D-ID",
-    "url": "https://www.d-id.com/pricing/studio/",
-    "favicon_url": "https://www.d-id.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "DALL-E",
-    "url": "https://openai.com/dall-e",
-    "favicon_url": "https://openai.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "DaVinci AI",
-    "url": "https://davinci.ai/app",
-    "favicon_url": "https://davinci.ai/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Flux",
-    "url": "https://www.fal.ai/flux",
-    "favicon_url": "https://www.fal.ai/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Higgsfield AI",
-    "url": "https://higgsfield.ai/",
-    "favicon_url": "https://higgsfield.ai/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Ideogram",
-    "url": "https://ideogram.ai/",
-    "favicon_url": "https://ideogram.ai/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Leonardo AI",
-    "url": "https://app.leonardo.ai/",
-    "favicon_url": "https://app.leonardo.ai/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Microsoft Designer",
-    "url": "https://designer.microsoft.com/",
-    "favicon_url": "https://designer.microsoft.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "MidJourney",
-    "url": "https://www.midjourney.com/explore?tab=top_month",
-    "favicon_url": "https://www.midjourney.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "NightCafe",
-    "url": "https://nightcafe.studio/",
-    "favicon_url": "https://nightcafe.studio/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "OpenArt",
-    "url": "https://openart.ai/",
-    "favicon_url": "https://openart.ai/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Stable Diffusion",
-    "url": "https://stablediffusionweb.com/",
-    "favicon_url": "https://stablediffusionweb.com/favicon.ico",
-    "category": "🎨 Image Generation and Design",
-    "tags": [
-      "image",
-      "generation",
-      "design"
-    ]
-  },
-  {
-    "name": "Casetext",
-    "url": "https://www.casetext.com/",
-    "favicon_url": "https://www.casetext.com/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "Clio",
-    "url": "https://www.clio.com/",
-    "favicon_url": "https://www.clio.com/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "Everlaw",
-    "url": "https://www.everlaw.com/",
-    "favicon_url": "https://www.everlaw.com/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "Harvey",
-    "url": "https://www.harvey.ai/",
-    "favicon_url": "https://www.harvey.ai/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "Ironclad",
-    "url": "https://ironcladapp.com/",
-    "favicon_url": "https://ironcladapp.com/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "Lawgeex",
-    "url": "https://www.lawgeex.com/",
-    "favicon_url": "https://www.lawgeex.com/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "NexLaw",
-    "url": "https://www.nexlaw.ai/",
-    "favicon_url": "https://www.nexlaw.ai/favicon.ico",
-    "category": "💼 Legal",
-    "tags": [
-      "legal"
-    ]
-  },
-  {
-    "name": "FourKites",
-    "url": "https://www.fourkites.com/",
-    "favicon_url": "https://www.fourkites.com/favicon.ico",
-    "category": "📊 Logistics",
-    "tags": [
-      "logistics"
-    ]
-  },
-  {
-    "name": "Locus.sh",
-    "url": "https://locus.sh/",
-    "favicon_url": "https://locus.sh/favicon.ico",
-    "category": "📊 Logistics",
-    "tags": [
-      "logistics"
-    ]
-  },
-  {
-    "name": "Shippeo",
-    "url": "https://www.shippeo.com/",
-    "favicon_url": "https://www.shippeo.com/favicon.ico",
-    "category": "📊 Logistics",
-    "tags": [
-      "logistics"
-    ]
-  },
-  {
-    "name": "Beautiful.ai",
-    "url": "https://www.beautiful.ai/",
-    "favicon_url": "https://www.beautiful.ai/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Duolingo",
-    "url": "https://www.duolingo.com/",
-    "favicon_url": "https://www.duolingo.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Elicit",
-    "url": "https://elicit.org/",
-    "favicon_url": "https://elicit.org/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Gamma.app",
-    "url": "https://gamma.app/",
-    "favicon_url": "https://gamma.app/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Grammarly",
-    "url": "https://www.grammarly.com/",
-    "favicon_url": "https://www.grammarly.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Hugging Face",
-    "url": "https://huggingface.co/",
-    "favicon_url": "https://huggingface.co/favicon.ico",
-    "category": "🌐 Developer Platforms and APIs",
-    "tags": [
-      "datasets",
-      "models",
-      "transformers"
-    ]
-  },
-  {
-    "name": "IBM Watson",
-    "url": "https://dataplatform.cloud.ibm.com/",
-    "favicon_url": "https://dataplatform.cloud.ibm.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Kaggle",
-    "url": "https://www.kaggle.com/",
-    "favicon_url": "https://www.kaggle.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Kahoot! AI",
-    "url": "https://kahoot.com/ai/",
-    "favicon_url": "https://kahoot.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Otio",
-    "url": "https://otio.ai/",
-    "favicon_url": "https://otio.ai/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Otter.ai",
-    "url": "https://otter.ai/",
-    "favicon_url": "https://otter.ai/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "QuillBot",
-    "url": "https://quillbot.com/",
-    "favicon_url": "https://quillbot.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Squirrel AI",
-    "url": "https://www.squirrelai.com/",
-    "favicon_url": "https://www.squirrelai.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Tableau AI",
-    "url": "https://www.tableau.com/products/ai",
-    "favicon_url": "https://www.tableau.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Wolfram Alpha",
-    "url": "https://www.wolframalpha.com/",
-    "favicon_url": "https://www.wolframalpha.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "YouChat",
-    "url": "https://you.com/",
-    "favicon_url": "https://you.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Zapier AI",
-    "url": "https://zapier.com/ai",
-    "favicon_url": "https://zapier.com/favicon.ico",
-    "category": "🔍 Research and Data Analysis",
-    "tags": [
-      "research",
-      "data",
-      "analysis"
-    ]
-  },
-  {
-    "name": "Algolia",
-    "url": "https://www.algolia.com/",
-    "favicon_url": "https://www.algolia.com/favicon.ico",
-    "category": "🛒 Retail",
-    "tags": [
-      "retail"
-    ]
-  },
-  {
-    "name": "Dynamic Yield",
-    "url": "https://www.dynamicyield.com/",
-    "favicon_url": "https://www.dynamicyield.com/favicon.ico",
-    "category": "🛒 Retail",
-    "tags": [
-      "retail"
-    ]
-  },
-  {
-    "name": "Nexla",
-    "url": "https://www.nexla.com/",
-    "favicon_url": "https://www.nexla.com/favicon.ico",
-    "category": "🛒 Retail",
-    "tags": [
-      "retail"
-    ]
-  },
-  {
-    "name": "Darktrace",
-    "url": "https://www.darktrace.com/",
-    "favicon_url": "https://www.darktrace.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Fireflies.ai",
-    "url": "https://fireflies.ai/",
-    "favicon_url": "https://fireflies.ai/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Gloat",
-    "url": "https://www.gloat.com/",
-    "favicon_url": "https://www.gloat.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Gong.io",
-    "url": "https://www.gong.io/",
-    "favicon_url": "https://www.gong.io/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Hailo",
-    "url": "https://www.hailo.ai/",
-    "favicon_url": "https://www.hailo.ai/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Lemonade",
-    "url": "https://www.lemonade.com/",
-    "favicon_url": "https://www.lemonade.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Microsoft Power Automate (with AI Builder)",
-    "url": "https://powerautomate.microsoft.com/en-us/ai-builder/",
-    "favicon_url": "https://powerautomate.microsoft.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Opendoor AI",
-    "url": "https://www.opendoor.com/ai",
-    "favicon_url": "https://www.opendoor.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Roofstock",
-    "url": "https://www.roofstock.com/",
-    "favicon_url": "https://www.roofstock.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Sportradar AI",
-    "url": "https://www.sportradar.com/ai",
-    "favicon_url": "https://www.sportradar.com/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Vellum",
-    "url": "https://www.vellum.ai/",
-    "favicon_url": "https://www.vellum.ai/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Zesty.ai",
-    "url": "https://www.zesty.ai/",
-    "favicon_url": "https://www.zesty.ai/favicon.ico",
-    "category": "🤖 Specialized",
-    "tags": [
-      "specialized"
-    ]
-  },
-  {
-    "name": "Amadeus AI",
-    "url": "https://amadeus.com/en/solutions/artificial-intelligence",
-    "favicon_url": "https://amadeus.com/favicon.ico",
-    "category": "🧭 Travel",
-    "tags": [
-      "travel"
-    ]
-  },
-  {
-    "name": "Hopper",
-    "url": "https://www.hopper.com/",
-    "favicon_url": "https://www.hopper.com/favicon.ico",
-    "category": "🧭 Travel",
-    "tags": [
-      "travel"
-    ]
-  },
-  {
-    "name": "Tripadvisor AI",
-    "url": "https://www.tripadvisor.com/ai",
-    "favicon_url": "https://www.tripadvisor.com/favicon.ico",
-    "category": "🧭 Travel",
-    "tags": [
-      "travel"
-    ]
-  },
-  {
-    "name": "CapCut",
-    "url": "https://www.capcut.com/",
-    "favicon_url": "https://www.capcut.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Clipchamp",
-    "url": "https://clipchamp.com/",
-    "favicon_url": "https://clipchamp.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Descript",
-    "url": "https://www.descript.com/",
-    "favicon_url": "https://www.descript.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "FlexClip",
-    "url": "https://www.flexclip.com/",
-    "favicon_url": "https://www.flexclip.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Hailuo AI",
-    "url": "https://hailuoai.video/",
-    "favicon_url": "https://hailuoai.video/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Hailuo AI Subscribe",
-    "url": "https://hailuoai.video/subscribe",
-    "favicon_url": "https://hailuoai.video/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Invideo AI",
-    "url": "https://invideo.io/",
-    "favicon_url": "https://invideo.io/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Jogg.ai",
-    "url": "https://www.jogg.ai/",
-    "favicon_url": "https://www.jogg.ai/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Kaiber",
-    "url": "https://kaiber.ai/",
-    "favicon_url": "https://kaiber.ai/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Kling AI",
-    "url": "https://www.klingai.com/",
-    "favicon_url": "https://www.klingai.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "LTX Studio",
-    "url": "https://app.ltx.studio/",
-    "favicon_url": "https://ltx.studio/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Neural Frames",
-    "url": "https://www.neuralframes.com/",
-    "favicon_url": "https://www.neuralframes.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Opus Clip",
-    "url": "https://www.opus.pro/",
-    "favicon_url": "https://www.opus.pro/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Pictory AI",
-    "url": "https://app.pictory.ai/",
-    "favicon_url": "https://pictory.ai/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Pika",
-    "url": "https://pika.art/login",
-    "favicon_url": "https://pika.art/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Plazmapunk",
-    "url": "https://app.plazmapunk.com/",
-    "favicon_url": "https://plazmapunk.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Revid AI",
-    "url": "https://www.revid.ai/",
-    "favicon_url": "https://www.revid.ai/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "RunwayML",
-    "url": "https://app.runwayml.com/",
-    "favicon_url": "https://app.runwayml.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Sora",
-    "url": "https://sora.chatgpt.com/",
-    "favicon_url": "https://sora.chatgpt.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Synthesia",
-    "url": "https://www.synthesia.io/",
-    "favicon_url": "https://www.synthesia.io/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Veed.io",
-    "url": "https://www.veed.io/",
-    "favicon_url": "https://www.veed.io/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Veo-2",
-    "url": "https://deepmind.google/technologies/veo/",
-    "favicon_url": "https://deepmind.google/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Vidnoz AI",
-    "url": "https://aiapp.vidnoz.com/",
-    "favicon_url": "https://vidnoz.com/favicon.ico",
-    "category": "🎬 Video Generation and Editing",
-    "tags": [
-      "video",
-      "generation",
-      "editing"
-    ]
-  },
-  {
-    "name": "Cody",
-    "url": "https://sourcegraph.com/cody",
-    "favicon_url": "https://sourcegraph.com/favicon.ico",
     "category": "💻 Coding and Development",
-    "tags": [
-      "coding",
-      "development"
+    "links": [
+      {
+        "name": "Bolt.new",
+        "url": "https://bolt.new/",
+        "favicon_url": "https://bolt.new/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Codeium",
+        "url": "https://codeium.com/",
+        "favicon_url": "https://codeium.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Codex by OpenAI",
+        "url": "https://chatgpt.com/codex",
+        "favicon_url": "https://chatgpt.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Codota",
+        "url": "https://www.tabnine.com/",
+        "favicon_url": "https://www.tabnine.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Cursor",
+        "url": "https://www.cursor.com/",
+        "favicon_url": "https://www.cursor.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "DeepCode",
+        "url": "https://www.snyk.io/deepcode/",
+        "favicon_url": "https://www.snyk.io/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "GitHub Copilot",
+        "url": "https://github.com/features/copilot",
+        "favicon_url": "https://github.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "GitHub Copilot Repo",
+        "url": "https://github.com/copilot",
+        "favicon_url": "https://github.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Google Code Assist",
+        "url": "https://codeassist.google.com/",
+        "favicon_url": "https://codeassist.google.com/favicon.ico",
+        "thumbnail_url": "https://example.com/thumbs/google-code-assist.png",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Jules",
+        "url": "https://jules.google.com/",
+        "favicon_url": "https://jules.google.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Phind",
+        "url": "https://www.phind.com/",
+        "favicon_url": "https://www.phind.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Qodex",
+        "url": "https://www.qodex.ai/",
+        "favicon_url": "https://www.qodex.ai/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Replit",
+        "url": "https://replit.com/",
+        "favicon_url": "https://replit.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      },
+      {
+        "name": "Cody",
+        "url": "https://sourcegraph.com/cody",
+        "favicon_url": "https://sourcegraph.com/favicon.ico",
+        "tags": [
+          "coding",
+          "development"
+        ]
+      }
     ]
   },
   {
-    "name": "Luma Labs",
-    "url": "https://lumalabs.ai/",
-    "favicon_url": "https://lumalabs.ai/favicon.ico",
+    "category": "💼 Legal",
+    "links": [
+      {
+        "name": "Casetext",
+        "url": "https://www.casetext.com/",
+        "favicon_url": "https://www.casetext.com/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      },
+      {
+        "name": "Clio",
+        "url": "https://www.clio.com/",
+        "favicon_url": "https://www.clio.com/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      },
+      {
+        "name": "Everlaw",
+        "url": "https://www.everlaw.com/",
+        "favicon_url": "https://www.everlaw.com/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      },
+      {
+        "name": "Harvey",
+        "url": "https://www.harvey.ai/",
+        "favicon_url": "https://www.harvey.ai/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      },
+      {
+        "name": "Ironclad",
+        "url": "https://ironcladapp.com/",
+        "favicon_url": "https://ironcladapp.com/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      },
+      {
+        "name": "Lawgeex",
+        "url": "https://www.lawgeex.com/",
+        "favicon_url": "https://www.lawgeex.com/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      },
+      {
+        "name": "NexLaw",
+        "url": "https://www.nexlaw.ai/",
+        "favicon_url": "https://www.nexlaw.ai/favicon.ico",
+        "tags": [
+          "legal"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "📊 Logistics",
+    "links": [
+      {
+        "name": "FourKites",
+        "url": "https://www.fourkites.com/",
+        "favicon_url": "https://www.fourkites.com/favicon.ico",
+        "tags": [
+          "logistics"
+        ]
+      },
+      {
+        "name": "Locus.sh",
+        "url": "https://locus.sh/",
+        "favicon_url": "https://locus.sh/favicon.ico",
+        "tags": [
+          "logistics"
+        ]
+      },
+      {
+        "name": "Shippeo",
+        "url": "https://www.shippeo.com/",
+        "favicon_url": "https://www.shippeo.com/favicon.ico",
+        "tags": [
+          "logistics"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "📚 Articles and Reviews",
+    "links": [
+      {
+        "name": "AI Pool Tools",
+        "url": "https://tools.aipoool.com/",
+        "favicon_url": "./favicon.ico",
+        "tags": [
+          "articles",
+          "reviews"
+        ]
+      },
+      {
+        "name": "SongBeast AI Review by Decortweaks",
+        "url": "https://decortweaks.com/songbeast-ai-review/",
+        "favicon_url": "./favicon.ico",
+        "tags": [
+          "articles",
+          "reviews"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "🔊 Audio, Music, and Speech",
+    "links": [
+      {
+        "name": "AIVA",
+        "url": "https://www.aiva.ai/",
+        "favicon_url": "https://www.aiva.ai/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "AssemblyAI",
+        "url": "https://www.assemblyai.com/",
+        "favicon_url": "https://www.assemblyai.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "ElevenLabs",
+        "url": "https://elevenlabs.io/app/home",
+        "favicon_url": "https://elevenlabs.io/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Freebeat.ai",
+        "url": "https://freebeat.ai/",
+        "favicon_url": "https://freebeat.ai/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Landr",
+        "url": "https://app.landr.com/",
+        "favicon_url": "https://app.landr.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Mubert",
+        "url": "https://mubert.com/",
+        "favicon_url": "https://mubert.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Murf.ai",
+        "url": "https://murf.ai/",
+        "favicon_url": "https://murf.ai/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Play.ht",
+        "url": "https://play.ht/",
+        "favicon_url": "https://play.ht/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "SongBeast AI",
+        "url": "https://songbeastai.com/",
+        "favicon_url": "https://songbeastai.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "SoundGen.io",
+        "url": "https://soundgen.io/",
+        "favicon_url": "https://soundgen.io/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Soundraw",
+        "url": "https://soundraw.io/",
+        "favicon_url": "https://soundraw.io/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Suno",
+        "url": "https://suno.com/invite/@nathanneurotic",
+        "favicon_url": "https://suno.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Suno Create",
+        "url": "https://suno.com/create?wid=default",
+        "favicon_url": "https://suno.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Synthesizer V",
+        "url": "https://dreamtonics.com/synthesizerv/",
+        "favicon_url": "https://dreamtonics.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Udio",
+        "url": "https://www.udio.com/creators/NathanNeurotic",
+        "favicon_url": "https://www.udio.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Udio Create",
+        "url": "https://www.udio.com/create",
+        "favicon_url": "https://www.udio.com/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      },
+      {
+        "name": "Voicemod AI Voices",
+        "url": "https://www.voicemod.net/ai-voices/",
+        "favicon_url": "https://www.voicemod.net/favicon.ico",
+        "tags": [
+          "audio",
+          "music",
+          "speech"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "🔍 Research and Data Analysis",
+    "links": [
+      {
+        "name": "Beautiful.ai",
+        "url": "https://www.beautiful.ai/",
+        "favicon_url": "https://www.beautiful.ai/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Duolingo",
+        "url": "https://www.duolingo.com/",
+        "favicon_url": "https://www.duolingo.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Elicit",
+        "url": "https://elicit.org/",
+        "favicon_url": "https://elicit.org/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Gamma.app",
+        "url": "https://gamma.app/",
+        "favicon_url": "https://gamma.app/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Grammarly",
+        "url": "https://www.grammarly.com/",
+        "favicon_url": "https://www.grammarly.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "IBM Watson",
+        "url": "https://dataplatform.cloud.ibm.com/",
+        "favicon_url": "https://dataplatform.cloud.ibm.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Kaggle",
+        "url": "https://www.kaggle.com/",
+        "favicon_url": "https://www.kaggle.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Kahoot! AI",
+        "url": "https://kahoot.com/ai/",
+        "favicon_url": "https://kahoot.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Otio",
+        "url": "https://otio.ai/",
+        "favicon_url": "https://otio.ai/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Otter.ai",
+        "url": "https://otter.ai/",
+        "favicon_url": "https://otter.ai/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "QuillBot",
+        "url": "https://quillbot.com/",
+        "favicon_url": "https://quillbot.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Squirrel AI",
+        "url": "https://www.squirrelai.com/",
+        "favicon_url": "https://www.squirrelai.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Tableau AI",
+        "url": "https://www.tableau.com/products/ai",
+        "favicon_url": "https://www.tableau.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Wolfram Alpha",
+        "url": "https://www.wolframalpha.com/",
+        "favicon_url": "https://www.wolframalpha.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "YouChat",
+        "url": "https://you.com/",
+        "favicon_url": "https://you.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      },
+      {
+        "name": "Zapier AI",
+        "url": "https://zapier.com/ai",
+        "favicon_url": "https://zapier.com/favicon.ico",
+        "tags": [
+          "research",
+          "data",
+          "analysis"
+        ]
+      }
+    ]
+  },
+  {
     "category": "🔮 3D Modeling",
-    "tags": [
-      "3d",
-      "modeling"
+    "links": [
+      {
+        "name": "3D AI Studio",
+        "url": "https://www.3daistudio.com/",
+        "favicon_url": "https://www.3daistudio.com/favicon.ico",
+        "tags": [
+          "modeling",
+          "design"
+        ],
+        "thumbnail_url": "https://example.com/thumbs/3d-ai-studio.png"
+      },
+      {
+        "name": "3DAIMaker",
+        "url": "https://3daimaker.com/",
+        "favicon_url": "https://3daimaker.com/favicon.ico",
+        "tags": [
+          "creator"
+        ]
+      },
+      {
+        "name": "AI 3D Model Generator",
+        "url": "https://ai3dmodelgenerator.net/",
+        "favicon_url": "https://ai3dmodelgenerator.net/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "AITwo",
+        "url": "https://aitwo.co/",
+        "favicon_url": "https://aitwo.co/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Alpha3D",
+        "url": "https://www.alpha3d.io/",
+        "favicon_url": "https://www.alpha3d.io/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Backflip AI",
+        "url": "https://www.backflip.ai/",
+        "favicon_url": "https://www.backflip.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Bing Video Creator",
+        "url": "https://www.bing.com/images/create?&amp;ctype=video#",
+        "favicon_url": "https://www.bing.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "CGDream.ai",
+        "url": "https://cgdream.ai/",
+        "favicon_url": "https://cgdream.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Creati.ai",
+        "url": "https://creati.ai/",
+        "favicon_url": "https://creati.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "CSM AI",
+        "url": "https://www.csm.ai/",
+        "favicon_url": "https://www.csm.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "D5 Render",
+        "url": "https://www.d5render.com/",
+        "favicon_url": "https://www.d5render.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "DeepAI",
+        "url": "https://deepai.org/",
+        "favicon_url": "https://deepai.org/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "DreamFusion3D",
+        "url": "https://dreamfusion3d.github.io/",
+        "favicon_url": "https://dreamfusion3d.github.io/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Edworking 3D Model Generator",
+        "url": "https://edworking.com/ai-tools/3d-model-generator",
+        "favicon_url": "https://edworking.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Figma AI",
+        "url": "https://www.figma.com/ai/",
+        "favicon_url": "https://www.figma.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Figuro",
+        "url": "https://figuro.io/",
+        "favicon_url": "https://figuro.io/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Hunyuan3D",
+        "url": "https://hunyuan3-d.com/",
+        "favicon_url": "https://hunyuan3-d.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Hyper3D",
+        "url": "https://hyper3d.ai/",
+        "favicon_url": "https://hyper3d.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Instant3D",
+        "url": "https://www.instant3d.ai/",
+        "favicon_url": "https://www.instant3d.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Kaedim",
+        "url": "https://www.kaedim3d.com/",
+        "favicon_url": "https://www.kaedim3d.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Live3D",
+        "url": "https://live3d.io/",
+        "favicon_url": "https://live3d.io/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Luw AI",
+        "url": "https://luw.ai/",
+        "favicon_url": "https://luw.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Masterpiece X",
+        "url": "https://www.masterpiecex.com/",
+        "favicon_url": "https://www.masterpiecex.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "MazingXR",
+        "url": "https://mazingxr.com/",
+        "favicon_url": "https://mazingxr.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Meshy",
+        "url": "https://www.meshy.ai/",
+        "favicon_url": "https://www.meshy.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "NVIDIA Magic3D",
+        "url": "https://research.nvidia.com/labs/dir/magic3d/",
+        "favicon_url": "https://research.nvidia.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "PicassoIA",
+        "url": "https://picassoia.com/",
+        "favicon_url": "https://picassoia.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Pixcap",
+        "url": "https://pixcap.com/",
+        "favicon_url": "https://pixcap.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Point-E",
+        "url": "https://huggingface.co/spaces/User-2468/point-e",
+        "favicon_url": "https://openai.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "PromeAI",
+        "url": "https://www.promeai.pro/",
+        "favicon_url": "https://www.promeai.pro/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Shap-E",
+        "url": "https://huggingface.co/spaces/hysts/Shap-E",
+        "favicon_url": "https://openai.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Stable 3D",
+        "url": "https://stability.ai/stable-3d",
+        "favicon_url": "https://stability.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Tencent Hunyuan3D",
+        "url": "https://3d.hunyuan.tencent.com/",
+        "favicon_url": "https://3d.hunyuan.tencent.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "ThreeDee Design",
+        "url": "https://www.threedee.design/",
+        "favicon_url": "https://www.threedee.design/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Trellis3D",
+        "url": "https://trellis3d.ai/",
+        "favicon_url": "https://trellis3d.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Tripo3D",
+        "url": "https://www.tripo3d.ai/",
+        "favicon_url": "https://www.tripo3d.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Vidu",
+        "url": "https://www.vidu.com/",
+        "favicon_url": "https://www.vidu.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Vondy",
+        "url": "https://www.vondy.com/",
+        "favicon_url": "https://www.vondy.com/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      },
+      {
+        "name": "Luma Labs",
+        "url": "https://lumalabs.ai/",
+        "favicon_url": "https://lumalabs.ai/favicon.ico",
+        "tags": [
+          "3d",
+          "modeling"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "🛒 Retail",
+    "links": [
+      {
+        "name": "Algolia",
+        "url": "https://www.algolia.com/",
+        "favicon_url": "https://www.algolia.com/favicon.ico",
+        "tags": [
+          "retail"
+        ]
+      },
+      {
+        "name": "Dynamic Yield",
+        "url": "https://www.dynamicyield.com/",
+        "favicon_url": "https://www.dynamicyield.com/favicon.ico",
+        "tags": [
+          "retail"
+        ]
+      },
+      {
+        "name": "Nexla",
+        "url": "https://www.nexla.com/",
+        "favicon_url": "https://www.nexla.com/favicon.ico",
+        "tags": [
+          "retail"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "🤖 Specialized",
+    "links": [
+      {
+        "name": "Darktrace",
+        "url": "https://www.darktrace.com/",
+        "favicon_url": "https://www.darktrace.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Fireflies.ai",
+        "url": "https://fireflies.ai/",
+        "favicon_url": "https://fireflies.ai/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Gloat",
+        "url": "https://www.gloat.com/",
+        "favicon_url": "https://www.gloat.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Gong.io",
+        "url": "https://www.gong.io/",
+        "favicon_url": "https://www.gong.io/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Hailo",
+        "url": "https://www.hailo.ai/",
+        "favicon_url": "https://www.hailo.ai/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Lemonade",
+        "url": "https://www.lemonade.com/",
+        "favicon_url": "https://www.lemonade.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Microsoft Power Automate (with AI Builder)",
+        "url": "https://powerautomate.microsoft.com/en-us/ai-builder/",
+        "favicon_url": "https://powerautomate.microsoft.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Opendoor AI",
+        "url": "https://www.opendoor.com/ai",
+        "favicon_url": "https://www.opendoor.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Roofstock",
+        "url": "https://www.roofstock.com/",
+        "favicon_url": "https://www.roofstock.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Sportradar AI",
+        "url": "https://www.sportradar.com/ai",
+        "favicon_url": "https://www.sportradar.com/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Vellum",
+        "url": "https://www.vellum.ai/",
+        "favicon_url": "https://www.vellum.ai/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      },
+      {
+        "name": "Zesty.ai",
+        "url": "https://www.zesty.ai/",
+        "favicon_url": "https://www.zesty.ai/favicon.ico",
+        "tags": [
+          "specialized"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "🧭 Travel",
+    "links": [
+      {
+        "name": "Amadeus AI",
+        "url": "https://amadeus.com/en/solutions/artificial-intelligence",
+        "favicon_url": "https://amadeus.com/favicon.ico",
+        "tags": [
+          "travel"
+        ]
+      },
+      {
+        "name": "Hopper",
+        "url": "https://www.hopper.com/",
+        "favicon_url": "https://www.hopper.com/favicon.ico",
+        "tags": [
+          "travel"
+        ]
+      },
+      {
+        "name": "Tripadvisor AI",
+        "url": "https://www.tripadvisor.com/ai",
+        "favicon_url": "https://www.tripadvisor.com/favicon.ico",
+        "tags": [
+          "travel"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "🩺 Healthcare",
+    "links": [
+      {
+        "name": "Aidoc",
+        "url": "https://www.aidoc.com/",
+        "favicon_url": "https://www.aidoc.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "DeepMind Health",
+        "url": "https://www.deepmind.com/health",
+        "favicon_url": "https://www.deepmind.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "Merative",
+        "url": "https://www.merative.com/",
+        "favicon_url": "https://www.merative.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "PathAI",
+        "url": "https://www.pathai.com/",
+        "favicon_url": "https://www.pathai.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "Tempus",
+        "url": "https://www.tempus.com/",
+        "favicon_url": "https://www.tempus.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "Viz.ai",
+        "url": "https://www.viz.ai/",
+        "favicon_url": "https://www.viz.ai/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "Welltok",
+        "url": "https://www.welltok.com/",
+        "favicon_url": "https://www.welltok.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      },
+      {
+        "name": "XpertDox",
+        "url": "https://www.xpertdox.com/",
+        "favicon_url": "https://www.xpertdox.com/favicon.ico",
+        "tags": [
+          "healthcare"
+        ]
+      }
     ]
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ps2links",
   "version": "1.0.0",
-  "description": "PS2 Resource Links is a static collection of PlayStation 2 related sites. The page is built from `links.json` and displayed with simple JavaScript and CSS.",
+  "description": "PS2 Resource Links is a static collection of PlayStation 2 related sites. The link data in `links.json` is organized by category and displayed with simple JavaScript and CSS.",
   "main": "script.js",
   "scripts": {
     "test": "playwright test --config=tests/playwright.config.js"

--- a/service-worker.js
+++ b/service-worker.js
@@ -17,15 +17,16 @@ self.addEventListener('install', event => {
       const cache = await caches.open(CACHE_NAME);
       await cache.addAll(URLS_TO_CACHE);
       try {
-        const resp = await fetch('./links.json');
-        const services = await resp.json();
-        for (const svc of services) {
-          if (svc.favicon_url) {
-            try { await cache.add(svc.favicon_url); } catch (e) { /* ignore */ }
-          }
-          if (svc.thumbnail_url) {
-            try { await cache.add(svc.thumbnail_url); } catch (e) { /* ignore */
- }
+        const resp = await fetch("./links.json");
+        const categories = await resp.json();
+        for (const cat of categories) {
+          for (const svc of cat.links) {
+            if (svc.favicon_url) {
+              try { await cache.add(svc.favicon_url); } catch (e) { /* ignore */ }
+            }
+            if (svc.thumbnail_url) {
+              try { await cache.add(svc.thumbnail_url); } catch (e) { /* ignore */ }
+            }
           }
         }
       } catch (err) {

--- a/tests/ui.spec.js
+++ b/tests/ui.spec.js
@@ -306,20 +306,23 @@ test('No horizontal scrollbar in block view on wider screens', async ({ page }) 
 test('should handle long service names with wrapping and scrolling', async ({ page }) => {
   const mockServices = [
     {
-      "name": "ThisIsAnExtremelyLongServiceNameDesignedToTestTheUIWrappingAndScrollingBehaviorItJustKeepsGoingAndGoingAndGoingAndGoingAndGoingAndGoingAndGoingAndGoingOnAndOnAndOn",
-      "url": "http://example.com/longname",
-      "favicon_url": "./favicon.ico",
-      "category": "Long Text Test",
-      "tags": ["test", "longname"],
-      "thumbnail_url": ""
-    },
-    {
-      "name": "Normal Service 1",
-      "url": "http://example.com/normal1",
-      "favicon_url": "./favicon.ico",
-      "category": "Long Text Test",
-      "tags": ["test"],
-      "thumbnail_url": ""
+      category: "Long Text Test",
+      links: [
+        {
+          name: "ThisIsAnExtremelyLongServiceNameDesignedToTestTheUIWrappingAndScrollingBehaviorItJustKeepsGoingAndGoingAndGoingAndGoingAndGoingAndGoingAndGoingAndGoingOnAndOnAndOn",
+          url: "http://example.com/longname",
+          favicon_url: "./favicon.ico",
+          tags: ["test", "longname"],
+          thumbnail_url: ""
+        },
+        {
+          name: "Normal Service 1",
+          url: "http://example.com/normal1",
+          favicon_url: "./favicon.ico",
+          tags: ["test"],
+          thumbnail_url: ""
+        }
+      ]
     }
   ];
 


### PR DESCRIPTION
## Summary
- convert links.json data to category objects containing a `links` array
- update service worker caching logic for new format
- adapt Playwright test mock data
- clarify README and package.json about the nested JSON structure

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a56983db883218eb43c606692f411