### PR TITLE
Remove leftover debug logging

### DIFF
--- a/script.js
+++ b/script.js
@@ -178,15 +178,13 @@ async function loadServices() {
                     categoryName
                 );
                 categoryContent.appendChild(serviceButton);
-                console.log('Created and appended service button: ' + service.name + ' in category: ' + categoryName);
             });
 
             categorySection.appendChild(categoryHeader);
             categorySection.appendChild(categoryContent);
             mainContainer.appendChild(categorySection);
         }
-        console.log('Finished processing categories. Total categories processed: ' + sortedCategoryNames.length);
-
+        
         renderFavoritesCategory();
 
         // Restore Category States from localStorage after dynamic loading


### PR DESCRIPTION
## Summary
- remove console logging when creating service buttons and after category processing

## Testing
- `npm test` *(fails: playwright missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a5863d2848321a6e18537270127b0