### PR TITLE
Refine view toggles and add Desktop View functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
         <button id="mobileToggle" onclick="toggleMobileView()" aria-label="Toggle mobile view" title="Toggle mobile view">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
         </button>
+        <button id="desktopToggle" type="button" title="Toggle desktop view" aria-label="Toggle desktop view">Desktop</button>
+        <button id="headerExpandAllBtn" onclick="expandAllCategories()" type="button" title="Expand all categories" aria-label="Expand all categories">Expand All</button>
+        <button id="headerCollapseAllBtn" onclick="collapseAllCategories()" type="button" title="Collapse all categories" aria-label="Collapse all categories">Collapse All</button>
         <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
     </header>
     <main>
@@ -40,8 +43,6 @@
             <input id="searchInput" type="text" placeholder="Search links..." aria-label="Search PS2 links" list="tagOptions" />
             <datalist id="tagOptions"></datalist>
             <small class="tag-hint">Search by tag using "tag1,tag2"</small>
-            <button id="expandAllBtn" onclick="expandAllCategories()" type="button" title="Expand all categories">Expand All</button>
-            <button id="collapseAllBtn" onclick="collapseAllCategories()" type="button" title="Collapse all categories">Collapse All</button>
         </div>
         <p id="noResults" class="no-results" hidden>No results found.</p>
         <!-- Service listings will be dynamically injected here by script.js -->
@@ -53,6 +54,7 @@
     <div id="updateNotification" hidden>
         New version available <button id="refreshBtn" title="Refresh to update">Refresh</button>
     </div>
+    <div id="sidebarOverlay"></div>
     <script src="./script.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -90,9 +90,12 @@ header { /* From reference */
 #themeToggle,
 #viewToggle,
 #mobileToggle,
+#desktopToggle,
+#headerExpandAllBtn,
+#headerCollapseAllBtn,
 #installBtn,
-#expandAllBtn,
-#collapseAllBtn,
+#expandAllBtn, /* Old, can be removed later if not reused */
+#collapseAllBtn, /* Old, can be removed later if not reused */
 #clearFavoritesBtn,
 #sidebarToggle {
     background: var(--button-gradient);
@@ -107,8 +110,8 @@ header { /* From reference */
     margin-top: 0; /* Align vertically in flex header if they are direct flex children */
 }
 /* Specific margins from reference */
-#viewToggle, #mobileToggle, #installBtn { margin-left: 0.5rem; } /* Kept for header buttons */
-#expandAllBtn, #collapseAllBtn { margin-left: 0.5rem; margin-top: 0.5rem; } /* For search buttons */
+#viewToggle, #mobileToggle, #desktopToggle, #headerExpandAllBtn, #headerCollapseAllBtn, #installBtn { margin-left: 0.5rem; } /* Kept for header buttons, added new ones */
+#expandAllBtn, #collapseAllBtn { margin-left: 0.5rem; margin-top: 0.5rem; } /* For old search buttons, can be removed later */
 #clearFavoritesBtn { font-size: 0.6rem; padding: 0.1rem 0.2rem; margin:0.5rem; margin-left:0.5rem;} /* from ref */
 #sidebarToggle {
     font-size: 1rem;
@@ -232,6 +235,10 @@ body.sidebar-open footer {
     margin-left: 200px;
     width: calc(100% - 200px);
     transition: margin-left 0.3s ease, width 0.3s ease;
+}
+
+body.sidebar-open {
+    overflow: hidden; /* Prevent body scroll when sidebar is open */
 }
 
 #header-favicon { /* From reference */
@@ -550,10 +557,26 @@ body.mobile-view .category-content { grid-template-columns: 1fr; }
 body.mobile-view header h1 { font-size: 1.6rem; }
 body.mobile-view .category h2 { font-size: 1.2rem; }
 body.mobile-view #searchInput { width: 90%; }
-body.mobile-view #viewToggle { display: none; } /* Hide global view toggle */
+/* Ensure #viewToggle is visible by default, removing specific hiding rules */
+/* body.mobile-view #viewToggle, body.desktop-view #viewToggle { display: none; } */
+
+/* Desktop view specific styles (mimicking block-view) */
+body.desktop-view main {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(var(--category-min-width), 1fr));
+    gap: 1rem;
+}
+body.desktop-view main > .search-container,
+body.desktop-view main > #favorites {
+    grid-column: 1 / -1; /* Make search and favorites span full width */
+}
+body.desktop-view .category {
+    margin-bottom: 0; /* Consistent with block-view category margin */
+}
+/* .category-content in desktop-view will use its default grid styling, which is desired. */
 
 @media (max-width: 768px) { /* General mobile styles from reference */
-    #viewToggle { display: none; } /* Hide global view toggle */
+    /* #viewToggle { display: none; } */ /* Ensure #viewToggle is visible by default */
     .category-content { grid-template-columns: 1fr; }
     body.block-view main { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); } /* Ref's seems to allow smaller cards on mobile in block view */
     header h1 { font-size: 1.6rem; }


### PR DESCRIPTION
This commit addresses feedback to more closely align with the reference project's view controls:

- Added a "Desktop View" button to the header:
    - Forces a multi-column layout for categories.
    - Interacts mutually exclusively with the "Mobile View" button.
    - State is persisted in localStorage.
- Ensured the global View Toggle (List/Block) button is always visible, removing previous CSS rules that hid it in mobile/desktop forced modes.
- Verified that per-category list/grid view toggles remain functional in all modes.
- Updated JavaScript for:
    - `toggleDesktopView()`: New function for desktop mode.
    - `toggleMobileView()`: Modified for interaction with desktop mode.
    - `updateHeaderButtonStates()`: Extended for new button states.
    - Page load initialization: Correctly applies saved desktop/mobile states.
- All associated HTML and CSS changes were made to support these features.
- I confirmed that all Playwright UI tests pass, ensuring functionality and no regressions.