### PR TITLE
Jules

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,14 +24,14 @@
     <header>
         <img id="header-favicon" src="./favicon.ico" alt="PS2Links Hub Favicon" />
         <h1 class="typing-effect">PS2Links Hub</h1>
-        <button id="themeToggle" onclick="toggleTheme()" aria-label="Toggle theme" title="Toggle theme">
+        <button id="themeToggle" aria-label="Toggle theme" title="Toggle theme">
             <svg id="themeIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
         </button>
-        <button id="viewToggle" onclick="toggleView()" aria-label="Toggle category view" title="Toggle category view">
+        <button id="viewToggle" aria-label="Toggle category view" title="Toggle category view">
             <svg id="viewIcon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
         </button>
         <button id="desktopToggle" type="button" title="Toggle desktop view" aria-label="Toggle desktop view"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>
-        <button id="mobileToggle" onclick="toggleMobileView()" aria-label="Toggle mobile view" title="Toggle mobile view">
+        <button id="mobileToggle" aria-label="Toggle mobile view" title="Toggle mobile view">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" ry="2"/><line x1="12" y1="18" x2="12.01" y2="18"/></svg>
         </button>
         <button id="installBtn" aria-label="Install app" title="Install app">Install App</button>
@@ -41,8 +41,8 @@
             <input id="searchInput" type="text" placeholder="Search links..." aria-label="Search PS2 links" list="tagOptions" />
             <datalist id="tagOptions"></datalist>
             <small class="tag-hint">Search by tag using "tag1,tag2"</small>
-            <button id="headerExpandAllBtn" onclick="expandAllCategories()" type="button" title="Expand all categories" aria-label="Expand all categories">Expand All</button>
-            <button id="headerCollapseAllBtn" onclick="collapseAllCategories()" type="button" title="Collapse all categories" aria-label="Collapse all categories">Collapse All</button>
+            <button id="headerExpandAllBtn" type="button" title="Expand all categories" aria-label="Expand all categories">Expand All</button>
+            <button id="headerCollapseAllBtn" type="button" title="Collapse all categories" aria-label="Collapse all categories">Collapse All</button>
         </div>
         <p id="noResults" class="no-results" hidden>No results found.</p>
         <!-- Service listings will be dynamically injected here by script.js -->

--- a/script.js
+++ b/script.js
@@ -61,15 +61,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Ensure mobileToggle event listener is correctly assigned
     const mobileToggleBtn = document.getElementById('mobileToggle');
-    if (mobileToggleBtn && !mobileToggleBtn.onclick) { // Check if onclick is not already set inline
+    if (mobileToggleBtn) { // Check if onclick is not already set inline
          mobileToggleBtn.addEventListener('click', toggleMobileView);
     }
     // Ensure viewToggle event listener is correctly assigned
     const viewToggleBtn = document.getElementById('viewToggle');
-    if (viewToggleBtn && !viewToggleBtn.onclick) { // Check if onclick is not already set inline
+    if (viewToggleBtn) { // Check if onclick is not already set inline
         viewToggleBtn.addEventListener('click', toggleView);
     }
 
+    const themeToggleBtn = document.getElementById('themeToggle');
+    if (themeToggleBtn) {
+        themeToggleBtn.addEventListener('click', toggleTheme);
+    }
+
+    const headerExpandAllBtn = document.getElementById('headerExpandAllBtn');
+    if (headerExpandAllBtn) {
+        headerExpandAllBtn.addEventListener('click', expandAllCategories);
+    }
+
+    const headerCollapseAllBtn = document.getElementById('headerCollapseAllBtn');
+    if (headerCollapseAllBtn) {
+        headerCollapseAllBtn.addEventListener('click', collapseAllCategories);
+    }
 
     const installBtn = document.getElementById('installBtn');
     if (installBtn) {
@@ -132,9 +146,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 bar.hidden = false;
                 const refresh = document.getElementById('refreshBtn');
                 if (refresh) {
-                    refresh.onclick = () => {
+                    refresh.addEventListener('click', () => {
                         worker.postMessage({ type: 'SKIP_WAITING' });
-                    };
+                    });
                 }
             }
 
@@ -211,7 +225,7 @@ async function loadServices() {
 
             const categoryHeader = document.createElement('h2');
             categoryHeader.setAttribute('aria-expanded', 'false');
-            categoryHeader.onclick = () => toggleCategory(categoryHeader);
+            categoryHeader.addEventListener('click', () => toggleCategory(categoryHeader));
             categoryHeader.tabIndex = 0;
             categoryHeader.addEventListener('keydown', (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -695,7 +709,6 @@ function toggleTheme() {
     localStorage.setItem('theme', isLight ? 'light' : 'dark');
     updateHeaderButtonStates();
 }
-window.toggleTheme = toggleTheme;
 
 function applySavedView() {
     const saved = localStorage.getItem('view');
@@ -733,7 +746,6 @@ function toggleView() { // This is for the global list/block view
     localStorage.setItem('view', isBlock ? 'block' : 'list');
     updateHeaderButtonStates(); // Renamed
 }
-window.toggleView = toggleView;
 
 function toggleMobileView() {
     document.body.classList.add('mobile-view');
@@ -767,7 +779,6 @@ function toggleCategoryView(categoryId) {
         toggle.classList.toggle('active', isList);
     }
 }
-window.toggleCategoryView = toggleCategoryView;
 
 function updateHeaderButtonStates() { // Renamed from updateToggleButtons
     const themeBtn = document.getElementById('themeToggle');
@@ -911,6 +922,4 @@ function populateTagDropdown() {
 
 // Make functions globally available if they are called via HTML onclick attributes
 window.populateTagDropdown = populateTagDropdown;
-window.expandAllCategories = expandAllCategories;
-window.collapseAllCategories = collapseAllCategories;
 // window.setupSidebarHighlighting = setupSidebarHighlighting; // Usually called internally


### PR DESCRIPTION
Fix: Standardize event handlers for all interactive buttons

This commit standardizes event handling across various buttons to improve
consistency and maintainability. It follows up on previous work that
addressed specific view toggle buttons.

Key changes:
- Standardized event handlers for header buttons:
    - Removed inline `onclick` from `#themeToggle`, `#headerExpandAllBtn`,
      and `#headerCollapseAllBtn` in `index.html`.
    - Attached event listeners using `addEventListener` in `script.js` for
      these buttons.
    - Removed now-unnecessary global assignments for their respective
      handler functions from `script.js`.
- Standardized event handlers for dynamically created category headers:
    - Changed `categoryHeader.onclick` to use `addEventListener` for the
      click event that expands/collapses categories in `script.js`.
- Standardized event handler for the service worker refresh button:
    - Changed `refreshBtn.onclick` to use `addEventListener` for the
      `#refreshBtn` in the update notification logic in `script.js`.

The internal logic of the button handler functions themselves was reviewed
and deemed sound. These changes ensure a more consistent approach to
event management throughout the application.