### PR TITLE
jules

### DIFF
--- a/script.js
+++ b/script.js
@@ -59,11 +59,12 @@ document.addEventListener('DOMContentLoaded', () => {
         desktopToggleBtn.addEventListener('click', toggleDesktopView);
     }
 
+    // Ensure mobileToggle event listener is correctly assigned
     const mobileToggleBtn = document.getElementById('mobileToggle');
     if (mobileToggleBtn) { // Check if onclick is not already set inline
          mobileToggleBtn.addEventListener('click', toggleMobileView);
     }
-
+    // Ensure viewToggle event listener is correctly assigned
     const viewToggleBtn = document.getElementById('viewToggle');
     if (viewToggleBtn) { // Check if onclick is not already set inline
         viewToggleBtn.addEventListener('click', toggleView);
@@ -83,7 +84,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (headerCollapseAllBtn) {
         headerCollapseAllBtn.addEventListener('click', collapseAllCategories);
     }
-
 
     const installBtn = document.getElementById('installBtn');
     if (installBtn) {

--- a/styles.css
+++ b/styles.css
@@ -131,6 +131,7 @@ header {
     margin-right: 1rem; /* PS2Links - spacing to its right */
     z-index:1100; /* PS2Links - keep if needed */
     transition: left 0.3s ease;
+    transform: translateZ(0); /* Added property */
 }
 
 
@@ -628,6 +629,34 @@ body.desktop-view.block-view .category {
     .category h2 { font-size: 1.2rem; } /* Consistent */
     #searchInput { width: 90%; } /* Consistent */
 }
+
+/* Enforce desktop view styles when body.desktop-view is active, overriding mobile defaults */
+body.desktop-view header h1 {
+    font-size: 2.5rem; /* Assuming this is the default desktop size */
+}
+
+body.desktop-view .category h2 {
+    font-size: 1.5rem; /* Assuming this is the default desktop size */
+}
+
+body.desktop-view .category-content {
+    grid-template-columns: repeat(auto-fill, minmax(var(--card-min-width), 1fr)); /* Desktop grid */
+}
+
+body.desktop-view #searchInput {
+    width: 70%; /* Default desktop width */
+    max-width: 550px; /* Default desktop max-width */
+}
+
+body.desktop-view header {
+    flex-wrap: nowrap; /* Assuming default is nowrap, countering 'wrap' from media query */
+}
+body.desktop-view header h1 {
+    flex-basis: auto; /* Resetting flex-basis if media query set it to 100% */
+    text-align: left; /* Assuming default is left, countering 'center' from media query */
+    /* margin-right: auto; is already on the base header h1 style */
+}
+
 
 #updateNotification { /* PS2Links specific, adapt with AI colors */
     position: fixed;


### PR DESCRIPTION
Fix: Strengthen CSS to enforce mobile/desktop view modes

This commit updates `styles.css` to ensure that the visual distinctions
between 'mobile view' and 'desktop view' are more effectively enforced,
particularly when 'desktop view' is selected on a narrow-screen device.

Previously, general mobile styles from an `@media (max-width: 768px)`
query would often override or make the 'desktop view' appear
indistinguishable from 'mobile view' on such devices.

Changes:
- Added specific CSS rules for `body.desktop-view` that explicitly define
  desktop-like styles for elements such as header font sizes,
  category title font sizes, category content grid layouts, search input
  width, and header flex properties.
- These new rules are intended to take precedence over the general
  mobile styles when `body.desktop-view` is active, thus providing a
  layout that more closely resembles a full desktop experience, even if
  it requires horizontal scrolling on a small screen.
- Existing `body.mobile-view` styles were deemed sufficient for defining
  the mobile-optimized layout.
- A re-check of the JavaScript confirmed that the logic for toggling
  `mobile-view` and `desktop-view` classes on the body element is
  correct.

This should address your feedback that the mobile and desktop view
toggles didn't result in noticeable layout changes on mobile devices.