### PR TITLE
Feat: Implement mobile-first default view detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,12 +30,21 @@ document.addEventListener('DOMContentLoaded', () => {
         localStorage.setItem('mobileViewActive', 'false');
         mobileIsActuallyActive = false; // update local flag
     } else if (!desktopIsActuallyActive && !mobileIsActuallyActive) {
-        // Neither is active (e.g., first visit or cleared storage). Default to desktop.
-        document.body.classList.add('desktop-view');
-        localStorage.setItem('desktopViewActive', 'true');
-        localStorage.setItem('mobileViewActive', 'false'); // Ensure mobile is marked false
+        // Neither is active (e.g., first visit or cleared storage). Detect and default.
+        if (window.innerWidth < 768) { // Check for mobile screen width
+            document.body.classList.add('mobile-view');
+            localStorage.setItem('mobileViewActive', 'true');
+            localStorage.setItem('desktopViewActive', 'false');
+        } else {
+            document.body.classList.add('desktop-view');
+            localStorage.setItem('desktopViewActive', 'true');
+            localStorage.setItem('mobileViewActive', 'false');
+        }
     } else if (desktopIsActuallyActive && !mobileIsActuallyActive) {
         // Desktop is solely active, ensure localStorage reflects this if it was ambiguous
+        // This case might be redundant now if the above block always sets one,
+        // but it doesn't hurt as a safeguard if applySavedDesktopView only set the class
+        // and not localStorage consistently before this block.
         localStorage.setItem('desktopViewActive', 'true');
         localStorage.setItem('mobileViewActive', 'false');
     } else if (!desktopIsActuallyActive && mobileIsActuallyActive) {


### PR DESCRIPTION
This commit modifies the initial view detection logic in `script.js`. Previously, on a first visit (with no view preference stored in localStorage), the application would always default to 'desktop view'.

With this change:
- On `DOMContentLoaded`, if no existing 'mobileViewActive' or 'desktopViewActive' preference is found in localStorage (simulating a first visit or cleared storage):
    - The script now checks `window.innerWidth`.
    - If `window.innerWidth < 768px` (matching the mobile CSS breakpoint), the application defaults to 'mobile view'.
    - Otherwise (on wider screens), it defaults to 'desktop view'.
- In both default cases, the appropriate class (`mobile-view` or `desktop-view`) is added to the body, and `localStorage` is updated to reflect this default choice.

This ensures that you on mobile devices get a mobile-optimized view by default on your first visit, improving the initial user experience. The existing logic for respecting saved preferences from localStorage remains unchanged.