### PR TITLE
jules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -628,6 +628,21 @@ body.desktop-view.block-view .category {
     }
     .category h2 { font-size: 1.2rem; } /* Consistent */
     #searchInput { width: 90%; } /* Consistent */
+
+    /* Ensure header in desktop-view on mobile still wraps and centers items */
+    body.desktop-view header {
+        flex-wrap: wrap;
+        justify-content: center; /* Re-apply from general mobile styles */
+        padding: 1rem; /* Re-apply from general mobile styles */
+        /* gap: 0.5rem; is already in the general mobile header style, might not need repeating if it cascades */
+    }
+
+    /* Ensure h1 in desktop-view on mobile takes full width and centers, allowing buttons below */
+    body.desktop-view header h1 {
+        flex-basis: 100%; /* Re-apply from general mobile styles */
+        text-align: center; /* Re-apply from general mobile styles */
+        font-size: 1.6rem; /* Compromise: use mobile H1 size for better fit, even in desktop view on mobile */
+    }
 }
 
 /* Enforce desktop view styles when body.desktop-view is active, overriding mobile defaults */


### PR DESCRIPTION
Fix: Ensure header is responsive in Desktop View on mobile devices

This commit adjusts CSS rules to prevent the header from breaking its
boundaries when "Desktop View" is enabled on a narrow screen (e.g., mobile).

Previously, when `body.desktop-view` was active, header elements were
forced to `flex-wrap: nowrap` and use larger desktop font sizes, causing
the header to overflow the viewport on small screens.

Changes in `styles.css`:
- Added new rules within the `@media (max-width: 768px)` query that
  specifically target `body.desktop-view header` and
  `body.desktop-view header h1`.
- These rules ensure that when desktop view is active on a screen
  narrower than 768px:
    - The `header` will use `flex-wrap: wrap`, `justify-content: center`,
      and mobile-appropriate padding.
    - The `header h1` will use `flex-basis: 100%`, `text-align: center`,
      and a smaller font size (`1.6rem`) suitable for mobile,
      overriding the larger desktop font size for the H1 in this specific context.
- The global `body.desktop-view` styles for header (nowrap, large H1)
  will continue to apply on screens wider than 768px.
- Styles for page *content* in desktop view (e.g., for categories,
  search input) remain unchanged and are intended to provide a
  desktop-like layout which may cause horizontal scrolling for the main
  content area, as expected by a "desktop view" feature.

This makes the header usable on mobile devices when desktop view is
selected, while still allowing the main page content to attempt to render
using desktop styles.